### PR TITLE
issue/#615-added-possibility-to-customize-plugins-work-directory

### DIFF
--- a/gravitee-plugin-core/src/main/java/io/gravitee/plugin/core/internal/PluginRegistryConfiguration.java
+++ b/gravitee-plugin-core/src/main/java/io/gravitee/plugin/core/internal/PluginRegistryConfiguration.java
@@ -29,6 +29,8 @@ import java.util.List;
  */
 public class PluginRegistryConfiguration {
 
+    private static final String PLUGIN_WORK_DIR_PROPERTY = "plugins.workDir";
+
     private final static String PLUGIN_PATH_PROPERTY = "plugins.path[%s]";
 
     @Value("${plugins.path:${gravitee.home}/plugins}")
@@ -38,6 +40,8 @@ public class PluginRegistryConfiguration {
 
     @Autowired
     private Environment environment;
+
+    private String pluginWorkDir;
 
     @PostConstruct
     public void init() {
@@ -57,6 +61,8 @@ public class PluginRegistryConfiguration {
         }
 
         pluginsPath = paths.toArray(new String []{});
+
+        pluginWorkDir = environment.getProperty(PLUGIN_WORK_DIR_PROPERTY);
     }
 
     public String[] getPluginsPath() {
@@ -66,4 +72,13 @@ public class PluginRegistryConfiguration {
     public void setPluginsPath(String[] pluginsPath) {
         this.pluginsPath = pluginsPath;
     }
+
+    public String getPluginWorkDir() {
+      return pluginWorkDir;
+    }
+
+    public void setPluginWorkDir(String pluginWorkDir) {
+      this.pluginWorkDir = pluginWorkDir;
+    }
+
 }

--- a/gravitee-plugin-core/src/main/java/io/gravitee/plugin/core/internal/PluginRegistryImpl.java
+++ b/gravitee-plugin-core/src/main/java/io/gravitee/plugin/core/internal/PluginRegistryImpl.java
@@ -23,6 +23,7 @@ import io.gravitee.plugin.core.utils.GlobMatchingFileVisitor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.util.StringUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -175,6 +176,15 @@ public class PluginRegistryImpl extends AbstractService implements PluginRegistr
             String sPluginFile = pluginArchivePath.toFile().getName();
             sPluginFile = sPluginFile.substring(0, sPluginFile.lastIndexOf(".zip"));
             Path workDir = FileSystems.getDefault().getPath(registryDir.getAbsolutePath(), ".work", sPluginFile);
+            if ( StringUtils.hasText(configuration.getPluginWorkDir()) ) {
+              // use specified workDir if specified in environment
+              workDir = FileSystems.getDefault().getPath(configuration.getPluginWorkDir(), sPluginFile);
+              // make sure the work dir exists
+              if ( !workDir.toFile().getParentFile().exists() ) {
+                workDir.toFile().getParentFile().mkdirs();
+              }
+            }
+
             FileUtils.delete(workDir);
 
             FileUtils.unzip(pluginArchivePath.toString(), workDir);


### PR DESCRIPTION
Added code to use custom work directory for plugins. The directory can be specified by the 'plugins.workDir' key. It has to be absolute.