### PR TITLE
Close URLClassLoader after usage.

### DIFF
--- a/gravitee-plugin-fetcher/src/main/java/io/gravitee/plugin/fetcher/internal/FetcherPluginHandler.java
+++ b/gravitee-plugin-fetcher/src/main/java/io/gravitee/plugin/fetcher/internal/FetcherPluginHandler.java
@@ -45,9 +45,8 @@ public class FetcherPluginHandler implements PluginHandler {
 
     @Override
     public void handle(Plugin plugin) {
-        try {
-            URLClassLoader fetcherClassLoader = new URLClassLoader(plugin.dependencies(),
-                    this.getClass().getClassLoader());
+        try (URLClassLoader fetcherClassLoader = new URLClassLoader(plugin.dependencies(),
+                    this.getClass().getClassLoader())) {
 
             Class<?> pluginClass = ClassUtils.forName(plugin.clazz(), fetcherClassLoader);
 

--- a/gravitee-plugin-service-discovery/src/main/java/io/gravitee/plugin/discovery/internal/ServiceDiscoveryPluginHandler.java
+++ b/gravitee-plugin-service-discovery/src/main/java/io/gravitee/plugin/discovery/internal/ServiceDiscoveryPluginHandler.java
@@ -45,10 +45,8 @@ public class ServiceDiscoveryPluginHandler implements PluginHandler {
 
     @Override
     public void handle(Plugin plugin) {
-        URLClassLoader serviceDiscoveryClassLoader = null;
-        try {
-            serviceDiscoveryClassLoader = new URLClassLoader(plugin.dependencies(),
-                    this.getClass().getClassLoader());
+        try (URLClassLoader serviceDiscoveryClassLoader = new URLClassLoader(plugin.dependencies(),
+                    this.getClass().getClassLoader())) {
 
             Class<?> pluginClass = ClassUtils.forName(plugin.clazz(), serviceDiscoveryClassLoader);
 


### PR DESCRIPTION
Close the URLClassLoader used to load the plugin class after loading it.
fixes https://github.com/gravitee-io/issues/issues/2920