### PR TITLE
fix: open design of plugin instantiation

### DIFF
--- a/gravitee-plugin-core/src/main/java/io/gravitee/plugin/core/api/PluginManifestFactory.java
+++ b/gravitee-plugin-core/src/main/java/io/gravitee/plugin/core/api/PluginManifestFactory.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.core.api;
+
+import io.gravitee.plugin.core.internal.PluginDependencyImpl;
+import io.gravitee.plugin.core.internal.PluginManifestProperties;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class PluginManifestFactory {
+
+    /**
+     * Create a manifest from a properties object.
+     *
+     * @param properties The properties object to read.
+     * @return A plugin manifest.
+     */
+    public static PluginManifest create(Properties properties) {
+        final String id = properties.getProperty(PluginManifestProperties.MANIFEST_ID_PROPERTY);
+        final String description = properties.getProperty(PluginManifestProperties.MANIFEST_DESCRIPTION_PROPERTY);
+        final String clazz = properties.getProperty(PluginManifestProperties.MANIFEST_CLASS_PROPERTY);
+        final String name = properties.getProperty(PluginManifestProperties.MANIFEST_NAME_PROPERTY);
+        final String version = properties.getProperty(PluginManifestProperties.MANIFEST_VERSION_PROPERTY);
+        final String type = properties.getProperty(PluginManifestProperties.MANIFEST_TYPE_PROPERTY);
+        final String category = properties.getProperty(PluginManifestProperties.MANIFEST_CATEGORY_PROPERTY);
+        final int priority = Integer.parseInt(properties.getProperty(PluginManifestProperties.MANIFEST_PRIORITY_PROPERTY, "1000"));
+        final List<PluginDependency> dependencies = Stream
+            .of(properties.getProperty(PluginManifestProperties.MANIFEST_DEPENDENCIES_PROPERTY, "").split(","))
+            .filter(s -> !"".equals(s))
+            .map(dependencyStr -> {
+                final String[] split = dependencyStr.split(":");
+
+                if (split.length == 1) {
+                    return new PluginDependencyImpl(split[0], "*");
+                } else {
+                    return new PluginDependencyImpl(split[0], split[1]);
+                }
+            })
+            .collect(Collectors.toList());
+
+        final Map<String, String> propertiesMap = new HashMap<>();
+        properties.forEach((o, o2) -> {
+            String key = o.toString();
+            if (!PluginManifestProperties.MANIFEST_PROPERTIES.contains(key)) {
+                propertiesMap.put(o.toString(), o2.toString());
+            }
+        });
+
+        return new PluginManifest() {
+            @Override
+            public String id() {
+                return id;
+            }
+
+            @Override
+            public String name() {
+                return name;
+            }
+
+            @Override
+            public String description() {
+                return description;
+            }
+
+            @Override
+            public String category() {
+                return category;
+            }
+
+            @Override
+            public String version() {
+                return version;
+            }
+
+            @Override
+            public String plugin() {
+                return clazz;
+            }
+
+            @Override
+            public String type() {
+                return type;
+            }
+
+            @Override
+            public int priority() {
+                return priority;
+            }
+
+            @Override
+            public List<io.gravitee.plugin.core.api.PluginDependency> dependencies() {
+                return dependencies;
+            }
+
+            @Override
+            public Map<String, String> properties() {
+                return propertiesMap;
+            }
+        };
+    }
+}

--- a/gravitee-plugin-core/src/main/java/io/gravitee/plugin/core/internal/PluginFactory.java
+++ b/gravitee-plugin-core/src/main/java/io/gravitee/plugin/core/internal/PluginFactory.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.core.internal;
+
+import io.gravitee.plugin.core.api.Plugin;
+import io.gravitee.plugin.core.api.PluginManifest;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class PluginFactory {
+
+    /**
+     * Create a Plugin instance from a {@link PluginManifest}
+     * @param manifest used to instantiate the plugin
+     * @return an instance of {@link PluginImpl}
+     */
+    public static Plugin from(PluginManifest manifest) {
+        return new PluginImpl(manifest);
+    }
+}

--- a/gravitee-plugin-core/src/main/java/io/gravitee/plugin/core/internal/PluginImpl.java
+++ b/gravitee-plugin-core/src/main/java/io/gravitee/plugin/core/internal/PluginImpl.java
@@ -27,7 +27,7 @@ import java.nio.file.Path;
 public class PluginImpl implements Plugin {
 
     private Path path;
-    private PluginManifest manifest;
+    private final PluginManifest manifest;
     private URL[] dependencies;
 
     PluginImpl(PluginManifest manifest) {

--- a/gravitee-plugin-policy/src/main/java/io/gravitee/plugin/policy/internal/PolicyPluginHandler.java
+++ b/gravitee-plugin-policy/src/main/java/io/gravitee/plugin/policy/internal/PolicyPluginHandler.java
@@ -56,11 +56,15 @@ public class PolicyPluginHandler extends AbstractSimplePluginHandler<PolicyPlugi
         policyPluginManager.register(policyPlugin);
 
         // Once registered, the classloader should be released
-        URLClassLoader classLoader = (URLClassLoader) policyPlugin.policy().getClassLoader();
-        try {
-            classLoader.close();
-        } catch (IOException e) {
-            logger.error("Unexpected exception while trying to release the policy classloader");
+        final ClassLoader policyClassLoader = policyPlugin.policy().getClassLoader();
+
+        if (policyClassLoader instanceof URLClassLoader) {
+            URLClassLoader classLoader = (URLClassLoader) policyClassLoader;
+            try {
+                classLoader.close();
+            } catch (IOException e) {
+                logger.error("Unexpected exception while trying to release the policy classloader");
+            }
         }
     }
 


### PR DESCRIPTION
**Issue

https://github.com/gravitee-io/issues/issues/7600

Description

Open the API so that the SDK is able to work with PluginManifest and PluginEventListener to take benefit from initialization phase of a policy plugin (PolicyContext.onActivation() needed by JavascriptPolicy for example)

@jhaeyaert, not a big fan of rising the visibility for PluginImpl since its in the internal package.
Maybe we can discuss that point.**
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.23.2-issues-7600-it-test-subclasses-2-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/plugin/gravitee-plugin/1.23.2-issues-7600-it-test-subclasses-2-SNAPSHOT/gravitee-plugin-1.23.2-issues-7600-it-test-subclasses-2-SNAPSHOT.zip)
  <!-- Version placeholder end -->
