### PR TITLE
feat: add deeper file search (in subfolders)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ workflows:
     setup_release:
         when:
             matches:
-                pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+                pattern: "/^[0-9]+\\.[0-9]+\\.[0-9]+(-(alpha|beta|rc)\\.[0-9]+)?$/"
                 value: << pipeline.git.tag >>
         jobs:
             - gravitee/setup_lib-release-config:
@@ -32,4 +32,4 @@ workflows:
                               - /.*/
                       tags:
                           only:
-                              - /^[0-9]+\.[0-9]+\.[0-9]+$/
+                              - /^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$/

--- a/gravitee-plugin-core/src/main/java/io/gravitee/plugin/core/api/AbstractConfigurablePluginManager.java
+++ b/gravitee-plugin-core/src/main/java/io/gravitee/plugin/core/api/AbstractConfigurablePluginManager.java
@@ -42,6 +42,11 @@ public abstract class AbstractConfigurablePluginManager<T extends ConfigurablePl
     }
 
     @Override
+    public String getSchema(String pluginId, String subFolder) throws IOException {
+        return getFirstFile(pluginId, String.format("%s/%s", SCHEMAS_DIRECTORY, subFolder));
+    }
+
+    @Override
     public String getIcon(String pluginId) throws IOException {
         T plugin = get(pluginId);
         Map<String, String> properties = plugin.manifest().properties();
@@ -78,17 +83,14 @@ public abstract class AbstractConfigurablePluginManager<T extends ConfigurablePl
         if (plugin != null) {
             Path workspaceDir = plugin.path();
 
-            File[] matches = workspaceDir.toFile().listFiles(pathname -> pathname.isDirectory() && pathname.getName().equals(directory));
+            final File dir = new File(workspaceDir.toString(), directory);
+            final File[] files = dir.listFiles(File::isFile);
 
-            if (matches.length == 1) {
-                File dir = matches[0];
-
-                if (dir.listFiles().length > 0) {
-                    return new String(Files.readAllBytes(dir.listFiles()[0].toPath()));
-                }
+            if (files != null && files.length > 0) {
+                return new String(Files.readAllBytes(files[0].toPath()));
             }
+            return null;
         }
-
         return null;
     }
 }

--- a/gravitee-plugin-core/src/main/java/io/gravitee/plugin/core/api/ConfigurablePluginManager.java
+++ b/gravitee-plugin-core/src/main/java/io/gravitee/plugin/core/api/ConfigurablePluginManager.java
@@ -23,4 +23,13 @@ import java.io.IOException;
  */
 public interface ConfigurablePluginManager<T extends ConfigurablePlugin> extends PluginManager<T> {
     String getSchema(String pluginId) throws IOException;
+
+    /**
+     * Get schema in a subfolder.
+     * @param pluginId is the id of the plugin we want to retrieve schema
+     * @param subFolder is the sub folder on which looks for the schema. Example: <code>getSchema("webhook", "subscriptions")</code>
+     * @return the schema as a {@link String}
+     * @throws IOException
+     */
+    String getSchema(String pluginId, String subFolder) throws IOException;
 }

--- a/gravitee-plugin-core/src/test/java/io/gravitee/plugin/core/api/AbstractConfigurablePluginManagerTest.java
+++ b/gravitee-plugin-core/src/test/java/io/gravitee/plugin/core/api/AbstractConfigurablePluginManagerTest.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.core.api;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class AbstractConfigurablePluginManagerTest {
+
+    public static final String FAKE_PLUGIN = "fake-plugin";
+    private AbstractConfigurablePluginManager<FakePlugin> cut;
+
+    @Before
+    public void setUp() {
+        cut =
+            new AbstractConfigurablePluginManager<FakePlugin>() {
+                @Override
+                public void register(FakePlugin plugin) {
+                    super.register(plugin);
+                }
+            };
+    }
+
+    @Test
+    public void shouldGetFirstSchemaFile() throws IOException {
+        cut.register(new FakePlugin());
+        final String schema = cut.getSchema(FAKE_PLUGIN);
+        assertEquals("{\n  \"schema\": \"configuration\"\n}", schema);
+    }
+
+    @Test
+    public void shouldGetFirstSchemaFileInSubFolder1() throws IOException {
+        cut.register(new FakePlugin());
+        final String schema = cut.getSchema(FAKE_PLUGIN, "subfolder_1");
+        assertEquals("{\n  \"schema\": \"subfolder_1\"\n}", schema);
+    }
+
+    @Test
+    public void shouldGetFirstSchemaFileInSubFolder2() throws IOException {
+        cut.register(new FakePlugin());
+        final String schema = cut.getSchema(FAKE_PLUGIN, "subfolder_1/subfolder_2");
+        assertEquals("{\n  \"schema\": \"subfolder_2\"\n}", schema);
+    }
+
+    @Test
+    public void shouldGetFirstDocumentationFile() throws IOException {
+        cut.register(new FakePlugin());
+        final String schema = cut.getDocumentation(FAKE_PLUGIN);
+        assertEquals("plugin documentation", schema);
+    }
+
+    private static class FakePlugin implements ConfigurablePlugin<String> {
+
+        @Override
+        public Class<String> configuration() {
+            return null;
+        }
+
+        @Override
+        public String id() {
+            return FAKE_PLUGIN;
+        }
+
+        @Override
+        public String clazz() {
+            return null;
+        }
+
+        @Override
+        public String type() {
+            return null;
+        }
+
+        @Override
+        public Path path() {
+            try {
+                return Paths.get(this.getClass().getClassLoader().getResource("files").toURI());
+            } catch (URISyntaxException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public PluginManifest manifest() {
+            return null;
+        }
+
+        @Override
+        public URL[] dependencies() {
+            return new URL[0];
+        }
+    }
+}

--- a/gravitee-plugin-core/src/test/resources/files/docs/doc.md
+++ b/gravitee-plugin-core/src/test/resources/files/docs/doc.md
@@ -1,0 +1,1 @@
+plugin documentation

--- a/gravitee-plugin-core/src/test/resources/files/schemas/schema-form.json
+++ b/gravitee-plugin-core/src/test/resources/files/schemas/schema-form.json
@@ -1,0 +1,3 @@
+{
+  "schema": "configuration"
+}

--- a/gravitee-plugin-core/src/test/resources/files/schemas/subfolder_1/schema-form.json
+++ b/gravitee-plugin-core/src/test/resources/files/schemas/subfolder_1/schema-form.json
@@ -1,0 +1,3 @@
+{
+  "schema": "subfolder_1"
+}

--- a/gravitee-plugin-core/src/test/resources/files/schemas/subfolder_1/subfolder_2/schema-form.json
+++ b/gravitee-plugin-core/src/test/resources/files/schemas/subfolder_1/subfolder_2/schema-form.json
@@ -1,0 +1,3 @@
+{
+  "schema": "subfolder_2"
+}


### PR DESCRIPTION
**Issue**

https://graviteecommunity.atlassian.net/browse/APIM-65

**Description**

Add capability to retrieve subscription schema form under schemas/subscriptions.

As for getSchema (which is looking in schemas folder), the first file is returned.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.25.0-apim-65-api-with-webhook-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/plugin/gravitee-plugin/1.25.0-apim-65-api-with-webhook-SNAPSHOT/gravitee-plugin-1.25.0-apim-65-api-with-webhook-SNAPSHOT.zip)
  <!-- Version placeholder end -->
