### PR TITLE
Add a type to the FetcherPluginHandler

### DIFF
--- a/gravitee-plugin-fetcher/src/main/java/io/gravitee/plugin/fetcher/internal/FetcherPluginHandler.java
+++ b/gravitee-plugin-fetcher/src/main/java/io/gravitee/plugin/fetcher/internal/FetcherPluginHandler.java
@@ -38,7 +38,7 @@ public class FetcherPluginHandler extends AbstractSimplePluginHandler<FetcherPlu
 
     @Override
     protected String type() {
-        return null;
+        return "fetchers";
     }
 
     @Override


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/XXXXX

**Description**

Add a type to the FetcherPluginHandler. Without any type, nobody was able to deactivate a fetcher with an env variable that looks like: `gravitee_fetchers_gitfetcher_enabled:false`
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.24.2-add-type-to-fetcher-plugins-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/plugin/gravitee-plugin/1.24.2-add-type-to-fetcher-plugins-SNAPSHOT/gravitee-plugin-1.24.2-add-type-to-fetcher-plugins-SNAPSHOT.zip)
  <!-- Version placeholder end -->
