### PR TITLE
fix: return null if file not found instead of Exception

### DIFF
--- a/gravitee-plugin-core/src/test/java/io/gravitee/plugin/core/api/AbstractConfigurablePluginManagerTest.java
+++ b/gravitee-plugin-core/src/test/java/io/gravitee/plugin/core/api/AbstractConfigurablePluginManagerTest.java
@@ -85,6 +85,14 @@ public class AbstractConfigurablePluginManagerTest {
         assertTrue(icon.startsWith("data:image/png;base64"));
     }
 
+    @Test
+    public void shouldGetNullIfFileNotFound() throws IOException {
+        cut.register(new FakePlugin());
+        properties.put("icon", "images/fake-path.png");
+        final String icon = cut.getIcon(FAKE_PLUGIN);
+        assertNull(icon);
+    }
+
     private static class FakePlugin implements ConfigurablePlugin<String> {
 
         @Override


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/XXXXX

**Description**

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.26.1-fix-icon-loading-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/plugin/gravitee-plugin/1.26.1-fix-icon-loading-SNAPSHOT/gravitee-plugin-1.26.1-fix-icon-loading-SNAPSHOT.zip)
  <!-- Version placeholder end -->
