### PR TITLE
Archi 230: add new plugin type for cluster

### DIFF
--- a/gravitee-plugin-alert/pom.xml
+++ b/gravitee-plugin-alert/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.plugin</groupId>
         <artifactId>gravitee-plugin</artifactId>
-        <version>1.26.1</version>
+        <version>1.27.0-archi-230-cluster-plugin-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-plugin-alert</artifactId>

--- a/gravitee-plugin-api/pom.xml
+++ b/gravitee-plugin-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.plugin</groupId>
         <artifactId>gravitee-plugin</artifactId>
-        <version>1.26.1</version>
+        <version>1.27.0-archi-230-cluster-plugin-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-plugin-api</artifactId>

--- a/gravitee-plugin-cockpit/pom.xml
+++ b/gravitee-plugin-cockpit/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>gravitee-plugin</artifactId>
         <groupId>io.gravitee.plugin</groupId>
-        <version>1.26.1</version>
+        <version>1.27.0-archi-230-cluster-plugin-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-plugin-cockpit</artifactId>

--- a/gravitee-plugin-connector/pom.xml
+++ b/gravitee-plugin-connector/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.plugin</groupId>
         <artifactId>gravitee-plugin</artifactId>
-        <version>1.26.1</version>
+        <version>1.27.0-archi-230-cluster-plugin-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-plugin-connector</artifactId>

--- a/gravitee-plugin-core/pom.xml
+++ b/gravitee-plugin-core/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.plugin</groupId>
         <artifactId>gravitee-plugin</artifactId>
-        <version>1.26.1</version>
+        <version>1.27.0-archi-230-cluster-plugin-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-plugin-core</artifactId>

--- a/gravitee-plugin-core/src/main/java/io/gravitee/plugin/core/api/PluginType.java
+++ b/gravitee-plugin-core/src/main/java/io/gravitee/plugin/core/api/PluginType.java
@@ -37,7 +37,8 @@ public enum PluginType {
     PROCESSOR,
     FACTOR,
     COCKPIT,
-    COCKPIT_CONTROLLER;
+    COCKPIT_CONTROLLER,
+    CLUSTER;
 
     public static PluginType from(String sType) {
         for (PluginType pluginType : values()) {

--- a/gravitee-plugin-core/src/main/java/io/gravitee/plugin/core/internal/PluginEventListener.java
+++ b/gravitee-plugin-core/src/main/java/io/gravitee/plugin/core/internal/PluginEventListener.java
@@ -22,7 +22,14 @@ import io.gravitee.common.service.AbstractService;
 import io.gravitee.plugin.core.api.Plugin;
 import io.gravitee.plugin.core.api.PluginEvent;
 import io.gravitee.plugin.core.api.PluginHandler;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -41,7 +48,7 @@ public class PluginEventListener extends AbstractService implements EventListene
     /**
      * Allows to define priority between the different plugin types.
      */
-    private static final List<String> pluginPriority = Arrays.asList("repository", "alert", "cockpit");
+    private static final List<String> pluginPriority = Arrays.asList("cluster", "repository", "alert", "cockpit");
 
     @Value("${plugins.failOnDuplicate:true}")
     private boolean failOnDuplicate;

--- a/gravitee-plugin-fetcher/pom.xml
+++ b/gravitee-plugin-fetcher/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.plugin</groupId>
         <artifactId>gravitee-plugin</artifactId>
-        <version>1.26.1</version>
+        <version>1.27.0-archi-230-cluster-plugin-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-plugin-fetcher</artifactId>

--- a/gravitee-plugin-identityprovider/pom.xml
+++ b/gravitee-plugin-identityprovider/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.plugin</groupId>
         <artifactId>gravitee-plugin</artifactId>
-        <version>1.26.1</version>
+        <version>1.27.0-archi-230-cluster-plugin-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-plugin-identityprovider</artifactId>

--- a/gravitee-plugin-notifier/pom.xml
+++ b/gravitee-plugin-notifier/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.plugin</groupId>
         <artifactId>gravitee-plugin</artifactId>
-        <version>1.26.1</version>
+        <version>1.27.0-archi-230-cluster-plugin-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-plugin-notifier</artifactId>

--- a/gravitee-plugin-policy/pom.xml
+++ b/gravitee-plugin-policy/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.plugin</groupId>
         <artifactId>gravitee-plugin</artifactId>
-        <version>1.26.1</version>
+        <version>1.27.0-archi-230-cluster-plugin-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-plugin-policy</artifactId>

--- a/gravitee-plugin-repository/pom.xml
+++ b/gravitee-plugin-repository/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.plugin</groupId>
         <artifactId>gravitee-plugin</artifactId>
-        <version>1.26.1</version>
+        <version>1.27.0-archi-230-cluster-plugin-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-plugin-repository</artifactId>

--- a/gravitee-plugin-resource/pom.xml
+++ b/gravitee-plugin-resource/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.plugin</groupId>
         <artifactId>gravitee-plugin</artifactId>
-        <version>1.26.1</version>
+        <version>1.27.0-archi-230-cluster-plugin-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-plugin-resource</artifactId>

--- a/gravitee-plugin-service-discovery/pom.xml
+++ b/gravitee-plugin-service-discovery/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.plugin</groupId>
         <artifactId>gravitee-plugin</artifactId>
-        <version>1.26.1</version>
+        <version>1.27.0-archi-230-cluster-plugin-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-plugin-service-discovery</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -24,12 +24,12 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>20.3</version>
+        <version>19.2.1</version>
     </parent>
 
     <groupId>io.gravitee.plugin</groupId>
     <artifactId>gravitee-plugin</artifactId>
-    <version>1.26.1</version>
+    <version>1.27.0-archi-230-cluster-plugin-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Gravitee.io APIM - Plugin</name>
 
@@ -47,7 +47,6 @@
         <gravitee-identityprovider-api.version>1.0.0</gravitee-identityprovider-api.version>
         <gravitee-cockpit-api.version>1.0.0</gravitee-cockpit-api.version>
         <gravitee-connector-api.version>1.0.0</gravitee-connector-api.version>
-        <gravitee-bom.version>2.8</gravitee-bom.version>
     </properties>
 
     <modules>
@@ -67,16 +66,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- Gravitee dependencies -->
-            <!-- Import bom to properly inherit all dependencies -->
-            <dependency>
-                <groupId>io.gravitee</groupId>
-                <artifactId>gravitee-bom</artifactId>
-                <version>${gravitee-bom.version}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-
             <!-- Self import modules -->
             <dependency>
                 <groupId>io.gravitee.plugin</groupId>
@@ -226,10 +215,12 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
+            <version>${spring.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
+            <version>${spring.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>
@@ -242,14 +233,17 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
+            <version>${logback.version}</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
+            <version>${logback.version}</version>
         </dependency>
 
         <!-- Unit Tests -->
@@ -262,6 +256,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -271,9 +266,9 @@
             <plugin>
                 <groupId>com.hubspot.maven.plugins</groupId>
                 <artifactId>prettier-maven-plugin</artifactId>
-                <version>0.17</version>
+                <version>0.18</version>
                 <configuration>
-                    <nodeVersion>12.13.0</nodeVersion>
+                    <nodeVersion>16.16.0</nodeVersion>
                     <prettierJavaVersion>1.6.1</prettierJavaVersion>
                 </configuration>
                 <executions>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/ARCHI-217
https://gravitee.atlassian.net/browse/ARCHI-230

## Description

Support new type of plugin

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.27.0-archi-230-cluster-plugin-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/plugin/gravitee-plugin/1.27.0-archi-230-cluster-plugin-SNAPSHOT/gravitee-plugin-1.27.0-archi-230-cluster-plugin-SNAPSHOT.zip)
  <!-- Version placeholder end -->
