### PR TITLE
feat: add new annotation and annotation processor to generate an eval…

### DIFF
--- a/gravitee-plugin-annotation-processors/README.adoc
+++ b/gravitee-plugin-annotation-processors/README.adoc
@@ -1,0 +1,181 @@
+= Annotation processors
+
+== ConfigurationEvaluator
+
+=== Goal
+
+This annotation is used to generate an evaluator at compile time for a specific configuration bean. This evaluator can then be used instead of the configuration bean to add the business logic needed to add dynamic evaluation of the properties contained in the configuration bean. The evaluator checks for every property if an attribute is present in the execution context to override its value and if the parameter is a string type, it also tries to evaluate its content using the template engine in case an EL was defined for this parameter.
+
+=== Parameters
+
+This annotation only takes one parameter which is `attributePrefix`. A string that represent the prefix the evaluator will use to determine if an attribute exist in the context to override a property. This prefix needs to respect the convention as explained below.
+
+As an example, here is how to use the annotation for the KafkaEndpointConnectorConfiguration.
+
+[source,java]
+----
+import io.gravitee.plugin.annotation.ConfigurationEvaluator;
+
+@ConfigurationEvaluator(attributePrefix = "gravitee.attributes.endpoint.kafka")
+public class KafkaEndpointConnectorConfiguration implements EndpointConnectorConfiguration {
+
+    private String bootstrapServers;
+}
+----
+
+==== Override configuration properties by attributes
+
+As describe above, using the evaluator generated instead of the classic configuration bean, we add the possibility for a user to override any property using an attribute (via the assign-attribute policy). In order to do so, we are using this convention for naming attribute: *[prefix].[type].[name].[field]*
+
+* Prefix: value is “gravitee.attributes”
+* Type : endpoint, entrypoint
+* Name : the name of the connector (ie : “kafka”)
+* Field : the name of the property to override (in lower camel case) or the path to it (ie: “bootstrapServers” or “consumer.topics” or “security.ssl.trustStore.type”)
+
+So if we want for example override the `bootstrapServers` attribute of the Kafka Endpoint, which is declared like this :
+
+[source, json]
+----
+"configuration": {
+    "bootstrapServers": "localhost:9094"
+}
+----
+
+You need to assign an attribute named `gravitee.attributes.endpoint.kafka.bootstrapServers`
+
+The annotation processor supports these types: String, Integer, Boolean, Enum, Set and List.
+
+==== Evaluate EL on string type properties
+
+If the property type is `string` and no attribute were found to override the original value, then the original value is evaluated using the template engine to transform it if it is an EL using the current context.
+
+So if we take the same example as before, we could override the bootstrapServers of our Kafka endpoint connector by using this configuration :
+
+[source, json]
+----
+"configuration": {
+    "bootstrapServers": "{#request.headers['mybootstrap'][0]}"
+}
+----
+
+In this example, if the request contains one header `mybootstrap`, then it will be used.
+
+==== Validate the dynamic configuration
+
+If you add in the configuration class of your plugin, Jakarta Bean Validation annotation on the fields that are not string type, you can ensure that the value we are trying to use dynamically for this property is valid and avoid unwanted issues.
+You can check the schema-form.json of your plugin to see actual constraint that are already used when validating the configuration and find the equivalent in the list of annotation (https://docs.jboss.org/hibernate/stable/validator/reference/en-US/html_single/#validator-defineconstraints-spec[List of annotations]).
+
+When validation fails, a log is produced containing the list of constraint violations (for each violation, you can see the name of the property and the reason of the failure), and an exception is thrown which is caught by the evaluator to interrupt the chain with a 500 status using this message `Invalid configuration` and this key `FAILURE_CONFIGURATION_INVALID`.
+
+Note that to avoid having a dependency on a Jakarta Expression Language implementation, the annotation does not support EL in the message. If you put one, the message in the log will be displayed without the EL being interpolated.
+
+**Warning : the generated evaluator is using `jakarta.validation` package and not `javax.validation`.**
+
+=== How to
+
+. Add the dependency to this module in your plugin project (do not forget to replace *VERSION*)
+
+[source, xml]
+----
+<dependency>
+    <groupId>io.gravitee.plugin</groupId>
+    <artifactId>gravitee-plugin-annotation-processors</artifactId>
+    <version>VERSION</version>
+    <scope>provided</scope>
+</dependency>
+----
+[start=2]
+. Add Hibernate Validator to your dependencies with a scope `provided` (this dependency was added in the Gateway to avoid duplication in each plugin using this annotation)
+
+[source, xml]
+----
+<dependency>
+    <groupId>org.hibernate.validator</groupId>
+    <artifactId>hibernate-validator</artifactId>
+    <version>8.0.1.Final</version>
+    <scope>provided</scope>
+</dependency>
+----
+[start=3]
+. Add this plugin in your pom.xml to define the generated sources as source file, so you can use them in your code in your IDE)
+
+[source, xml]
+----
+<plugin>
+    <groupId>org.codehaus.mojo</groupId>
+    <artifactId>build-helper-maven-plugin</artifactId>
+    <version>1.7</version>
+    <executions>
+        <execution>
+            <id>add-source</id>
+            <phase>generate-sources</phase>
+            <goals>
+                <goal>add-source</goal>
+            </goals>
+            <configuration>
+                <sources>
+                    <source>generated-sources</source>
+                </sources>
+            </configuration>
+        </execution>
+    </executions>
+</plugin>
+----
+[start=4]
+. Add the annotation `@ConfigurationEvaluator` at the class level of your plugin configuration classes (ie: KafkaEndpointConnectorConfiguration, KafkaEndpointConnectorSharedConfiguration) with the right value for the parameter `attributePrefix`
+. Add the validation annotations in your configuration classes as described in <<_validate_the_dynamic_configuration>>
+. Build your project to generate the new "ConfigurationEvaluator" classes (you can find them in the folder target/generated-sources/annotations)
+. Create all `evaluators` necessary in your constructor (only one attribute is required by the evaluator constructor which is the configuration bean) and call the `eval` method to generate the dynamic configuration object or retrieved it from the context if it has already been called once (it is stored in the context using an internal attribute to avoid multiple evaluation). Here you have an example for an endpoint :
+
+[source, java]
+----
+    // parts of the code are missing to focus on what needs to be changed
+
+    private final KafkaEndpointConnectorConfigurationEvaluator kafkaEndpointConnectorConfigurationEvaluator;
+
+    public KafkaEndpointConnector(
+        KafkaEndpointConnectorConfiguration configuration,
+        KafkaEndpointConnectorSharedConfiguration sharedConfiguration,
+        QosStrategyFactory qosStrategyFactory
+    ) {
+        this.configuration = configuration;
+        this.sharedConfiguration = sharedConfiguration;
+        this.qosStrategyFactory = qosStrategyFactory;
+        this.kafkaEndpointConnectorConfigurationEvaluator = new KafkaEndpointConnectorConfigurationEvaluator(configuration);
+    }
+
+    @Override
+    public Completable subscribe(final ExecutionContext ctx) {
+        return kafkaEndpointConnectorConfigurationEvaluator
+            .eval(ctx)
+            .flatMapCompletable(evaluatedConfiguration ->
+                // use the evaluated configuration in your code
+            );
+    }
+----
+[start=8]
+. Update your unit tests and you should be done
+
+=== Methods available in evaluator class
+
+The generated evaluator provides 3 methods that you can use :
+
+* public Single<ConfigurationClass> eval(ExecutionContext ctx) : default method to use which parse the original configuration using the given context and evaluate it in a reactive way then return the evaluated configuration
+* public ConfigurationClass evalNow() : equivalent to eval but *blocking*
+
+=== Contribute
+
+The annotation processor is working by parsing the configuration bean. For each field of the bean, a type is define (a simple field, an inner class or an object). Depending on this type, some information are gathered and passed to a Mustache template (the templates are in the directory src/main/resources/templates). These templates generate part of the Evaluator created for the configuration bean the annotation has been used on.
+If you want to add some logic in the Evaluator generated, you will certainly need to modify one of these templates. They are named to reflect what they are used for. The structure is the following:
+
+- evaluatorHeader: manage the generation of the first part of the evaluator (imports, class, constructor, all utility methods needed for each supported Java type like String, Enum etc and the validation).
+- evalClass/evalClose: manage object and inner class by adding around the field the necessary code
+- evalField: manage the code for a field
+- evaluatorFooter: manage the footer of the evaluator (the end of the eval method)
+
+We only call evaluatorHeader and evaluatorFooter templates once, but we loop on all fields/classes/objects and call the other templates if needed each time.
+
+To validate the generated code, unit tests have been developed with two classes:
+
+- ConfigurationEvaluatorProcessorTest: in charge of verifying that the code generated is the one expected by invoking the annotation processor on the class src/test/java/io/gravitee/plugin/annotation/processor/result/TestConfiguration.java and comparing the evaluator generated with the expected result in src/test/resources/test/TestConfigurationEvaluator.java. So if you change the code generated, you need to ensure that you also update this file to reflect the changes you were expected.
+- ConfigurationEvaluatorGeneratedTest: in charge of validating the logic of the code generated for the evaluator (for example, validate that if an attribute exist in the context to override a field which is an Enum in the configuration, the configuration evaluated is reflecting this).

--- a/gravitee-plugin-annotation-processors/pom.xml
+++ b/gravitee-plugin-annotation-processors/pom.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.gravitee.plugin</groupId>
+        <artifactId>gravitee-plugin</artifactId>
+        <version>2.0.2</version>
+    </parent>
+
+    <artifactId>gravitee-plugin-annotation-processors</artifactId>
+    <name>Gravitee.io - Plugin - Annotation Processors</name>
+
+    <properties>
+        <jakarta.validation-api.version>3.0.2</jakarta.validation-api.version>
+        <auto-service.version>1.1.0</auto-service.version>
+        <hibernate-validator.version>8.0.1.Final</hibernate-validator.version>
+        <mustache.version>0.9.10</mustache.version>
+        <compile-testing.version>0.21.0</compile-testing.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.auto.service</groupId>
+            <artifactId>auto-service</artifactId>
+            <version>${auto-service.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.spullara.mustache.java</groupId>
+            <artifactId>compiler</artifactId>
+            <version>${mustache.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <version>${jakarta.validation-api.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
+
+        <!-- Tests dependencies -->
+        <dependency>
+            <groupId>com.google.testing.compile</groupId>
+            <artifactId>compile-testing</artifactId>
+            <version>${compile-testing.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.reactivex.rxjava3</groupId>
+            <artifactId>rxjava</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>${hibernate-validator.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.18.1</version>
+                <configuration>
+                    <argLine>--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+                        --add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+                        --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+                    </argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/gravitee-plugin-annotation-processors/src/main/java/io/gravitee/plugin/annotation/ConfigurationEvaluator.java
+++ b/gravitee-plugin-annotation-processors/src/main/java/io/gravitee/plugin/annotation/ConfigurationEvaluator.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.SOURCE)
+public @interface ConfigurationEvaluator {
+    /**
+     * A string that represent the prefix the evaluator will use to determine
+     * if an attribute exist in the context to override a property.
+     * This prefix must follow the defined convention: gravitee.attributes.[type].[name]
+     * where type is the type of plugin (ie: "endpoint") and name is the name of the plugin (ie : “kafka”)
+     */
+    String attributePrefix();
+}

--- a/gravitee-plugin-annotation-processors/src/main/java/io/gravitee/plugin/annotation/processor/ConfigurationEvaluatorProcessor.java
+++ b/gravitee-plugin-annotation-processors/src/main/java/io/gravitee/plugin/annotation/processor/ConfigurationEvaluatorProcessor.java
@@ -1,0 +1,388 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.annotation.processor;
+
+import com.github.mustachejava.DefaultMustacheFactory;
+import com.github.mustachejava.Mustache;
+import com.github.mustachejava.MustacheFactory;
+import com.google.auto.service.AutoService;
+import io.gravitee.plugin.annotation.ConfigurationEvaluator;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.Writer;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.Messager;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.Processor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.PrimitiveType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Elements;
+import javax.tools.Diagnostic;
+import javax.tools.JavaFileObject;
+import lombok.Getter;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@SupportedAnnotationTypes("io.gravitee.plugin.annotation.ConfigurationEvaluator")
+@SupportedSourceVersion(SourceVersion.RELEASE_17)
+@AutoService(Processor.class)
+public class ConfigurationEvaluatorProcessor extends AbstractProcessor {
+
+    private Messager messager;
+
+    private Elements elementUtils;
+
+    @Override
+    public synchronized void init(ProcessingEnvironment processingEnv) {
+        super.init(processingEnv);
+        messager = processingEnv.getMessager();
+        elementUtils = processingEnv.getElementUtils();
+    }
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        for (TypeElement annotation : annotations) {
+            Set<? extends Element> annotatedElements = roundEnv.getElementsAnnotatedWith(annotation);
+
+            for (Element annotatedElement : annotatedElements) {
+                if (annotatedElement.getKind() == ElementKind.CLASS) {
+                    String attributePrefix = annotatedElement.getAnnotation(ConfigurationEvaluator.class).attributePrefix();
+
+                    if (attributePrefix == null || attributePrefix.isEmpty()) {
+                        messager.printMessage(
+                            Diagnostic.Kind.ERROR,
+                            "@ConfigurationEvaluator attributePrefix property must not be empty",
+                            annotatedElement
+                        );
+                    } else {
+                        String className = ((TypeElement) annotatedElement).getQualifiedName().toString();
+
+                        try {
+                            writeEvaluatorFileFromTemplate(className, (TypeElement) annotatedElement, attributePrefix);
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                } else {
+                    messager.printMessage(Diagnostic.Kind.ERROR, "@ConfigurationEvaluator should be use on class", annotatedElement);
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private void writeEvaluatorFileFromTemplate(final String className, final TypeElement currentElement, final String attributePrefix)
+        throws IOException {
+        String packageName = null;
+        int lastDot = className.lastIndexOf('.');
+        if (lastDot > 0) {
+            packageName = className.substring(0, lastDot);
+        }
+
+        String simpleClassName = className.substring(lastDot + 1);
+        String evaluatorClassName = className + "Evaluator";
+        String evaluatorSimpleClassName = evaluatorClassName.substring(lastDot + 1);
+        String evaluatedConfigurationName = toCamelCase(simpleClassName);
+
+        JavaFileObject evaluatorFile = processingEnv.getFiler().createSourceFile(evaluatorClassName);
+
+        try (PrintWriter out = new PrintWriter(evaluatorFile.openWriter())) {
+            HashMap<String, Object> scopes = new HashMap<>();
+            scopes.put("packageName", packageName);
+            scopes.put("simpleClassName", simpleClassName);
+            scopes.put("evaluatorClassName", evaluatorClassName);
+            scopes.put("evaluatorSimpleClassName", evaluatorSimpleClassName);
+            scopes.put("evaluatedConfigurationName", evaluatedConfigurationName);
+            scopes.put("attributePrefix", attributePrefix);
+
+            MustacheFactory mf = new DefaultMustacheFactory();
+            Mustache mHeader = mf.compile("templates/evaluatorHeader.mustache");
+            Mustache mFooter = mf.compile("templates/evaluatorFooter.mustache");
+            Mustache mClass = mf.compile("templates/evalClass.mustache");
+            Mustache mField = mf.compile("templates/evalField.mustache");
+            Mustache mClose = mf.compile("templates/evalClose.mustache");
+
+            //First header
+            mHeader.execute(out, scopes);
+
+            //Then eval method
+            generateEvalMethods(currentElement, mClass, mField, mClose, out, "evaluatedConfiguration", "configuration", "");
+
+            //Then footer
+            mFooter.execute(out, scopes);
+
+            out.flush();
+        }
+    }
+
+    private void generateEvalMethods(
+        TypeElement currentElement,
+        Mustache mClass,
+        Mustache mField,
+        Mustache mClose,
+        Writer writer,
+        String evaluatedConfigurationName,
+        String originalConfigurationName,
+        String currentAttributeSuffix
+    ) {
+        // 3 things to manage : fields, inner class and object
+        // We need to exclude the "builder" part if present
+        List<VariableElement> fields = elementUtils
+            .getAllMembers(currentElement)
+            .stream()
+            .filter(element -> element.getKind() == ElementKind.FIELD && !element.getSimpleName().toString().contains("Builder"))
+            .map(element -> (VariableElement) element)
+            .toList();
+
+        Map<Boolean, List<FieldProperty>> convertedFields = fields
+            .stream()
+            .map(field -> new FieldProperty(field, elementUtils, evaluatedConfigurationName, originalConfigurationName))
+            .collect(Collectors.partitioningBy(fieldProperty -> "Object".equals(fieldProperty.getFieldType())));
+
+        List<TypeElement> classes = elementUtils
+            .getAllMembers(currentElement)
+            .stream()
+            .filter(element -> element.getKind() == ElementKind.CLASS && !element.getSimpleName().toString().contains("Builder"))
+            .map(element -> (TypeElement) element)
+            .toList();
+
+        // Process fields
+        convertedFields.get(false).forEach(field -> mField.execute(writer, field));
+
+        // Process classes
+        classes.forEach(classElement -> {
+            String className = classElement.getSimpleName().toString();
+            String classVariable = toCamelCase(className);
+            String classGetter = getGetterMethod(className);
+            String attributeSuffix = currentAttributeSuffix + "." + classVariable;
+            String evaluatedConf = evaluatedConfigurationName + "." + classGetter;
+            String originalConf = originalConfigurationName + "." + classGetter;
+
+            Map<String, Object> scopes = new HashMap<>();
+            scopes.put("className", className);
+            scopes.put("attributeSuffix", attributeSuffix);
+            scopes.put("evaluatedConfigurationName", evaluatedConf);
+            mClass.execute(writer, scopes);
+
+            generateEvalMethods(classElement, mClass, mField, mClose, writer, evaluatedConf, originalConf, attributeSuffix);
+
+            mClose.execute(writer, scopes);
+        });
+
+        // Process objects
+        List<FieldProperty> objects = convertedFields
+            .get(true)
+            .stream()
+            .filter(fieldProperty ->
+                classes.stream().noneMatch(cl -> cl.getSimpleName().toString().equalsIgnoreCase(fieldProperty.getFieldName()))
+            )
+            .toList();
+
+        objects.forEach(objectElement -> {
+            String objectName = objectElement.fieldName;
+            String objectGetter = getGetterMethod(objectName);
+            String attributeSuffix = currentAttributeSuffix + "." + objectName;
+            String evaluatedConf = evaluatedConfigurationName + "." + objectGetter;
+            String originalConf = originalConfigurationName + "." + objectGetter;
+
+            Map<String, Object> scopes = new HashMap<>();
+            scopes.put("className", objectName);
+            scopes.put("attributeSuffix", attributeSuffix);
+            scopes.put("evaluatedConfigurationName", evaluatedConf);
+            mClass.execute(writer, scopes);
+
+            TypeElement element = elementUtils.getTypeElement(((DeclaredType) objectElement.getField().asType()).asElement().toString());
+
+            //Check if element is not null and throw an exception with debug info
+            if (element == null) {
+                throw new RuntimeException(
+                    "Element is null for " +
+                    objectElement.getFieldName() +
+                    " and type " +
+                    objectElement.getField().asType().toString() +
+                    " and asElement " +
+                    ((DeclaredType) objectElement.getField().asType()).asElement().toString()
+                );
+            }
+
+            generateEvalMethods(element, mClass, mField, mClose, writer, evaluatedConf, originalConf, attributeSuffix);
+
+            mClose.execute(writer, scopes);
+        });
+    }
+
+    private String getGetterMethod(final String field) {
+        String startLetter = field.substring(0, 1).toUpperCase();
+        return "get" + startLetter + field.substring(1) + "()";
+    }
+
+    private String toCamelCase(final String className) {
+        String startLetter = className.substring(0, 1).toLowerCase();
+        return startLetter + className.substring(1);
+    }
+
+    @Getter
+    public static class FieldProperty {
+
+        private final VariableElement field;
+        private final Elements elementUtils;
+        private final String fieldName;
+        private final String fieldGetter;
+        private final String fieldSetter;
+        private final String fieldType;
+        private final String fieldClass;
+
+        private final boolean toEval;
+        private final String evaluatedConfigurationName;
+        private final String originalConfigurationName;
+
+        public FieldProperty(
+            VariableElement field,
+            Elements elementUtils,
+            String evaluatedConfigurationName,
+            String originalConfigurationName
+        ) {
+            this.field = field;
+            this.elementUtils = elementUtils;
+            this.fieldType = getFieldType(field);
+            this.fieldName = field.getSimpleName().toString();
+            this.fieldGetter = getGetterMethod(fieldName, fieldType);
+            this.fieldSetter = getSetterMethod(fieldName);
+            // Check if the type of this field is String to know if it's need to be evaluated by the template engine
+            this.toEval = "String".equals(fieldType);
+            this.evaluatedConfigurationName = evaluatedConfigurationName;
+            this.originalConfigurationName = originalConfigurationName;
+            this.fieldClass = "Enum".equals(fieldType) ? field.asType().toString() : "";
+        }
+
+        private String getGetterMethod(String field, String fieldType) {
+            String startLetter = field.substring(0, 1).toUpperCase();
+            String prefix = "get";
+            if ("Boolean".equals(fieldType)) {
+                prefix = "is";
+            }
+            return prefix + startLetter + field.substring(1);
+        }
+
+        private String getSetterMethod(String field) {
+            String startLetter = field.substring(0, 1).toUpperCase();
+            return "set" + startLetter + field.substring(1);
+        }
+
+        /**
+         * Compare a field to various types to find it
+         * @param field the field to test
+         * @return a String representing the type found (if no type matches, the default type is Object)
+         */
+        private String getFieldType(VariableElement field) {
+            if (is(field.asType(), String.class)) {
+                return "String";
+            } else if (is(field.asType(), Boolean.class) || is(field.asType(), boolean.class)) {
+                return "Boolean";
+            } else if (is(field.asType(), Set.class)) {
+                return "Set";
+            } else if (is(field.asType(), List.class)) {
+                return "List";
+            } else if (is(field.asType(), Integer.class) || is(field.asType(), int.class)) {
+                return "Integer";
+            } else if (is(field.asType(), Long.class) || is(field.asType(), long.class)) {
+                return "Long";
+            } else if (is(field.asType(), Double.class) || is(field.asType(), double.class)) {
+                return "Double";
+            } else if (is(field.asType(), Short.class) || is(field.asType(), short.class)) {
+                return "Short";
+            } else if (isEnum(field.asType())) {
+                return "Enum";
+            }
+            return "Object";
+        }
+
+        /**
+         * Check if the given type is an Enum
+         * @param type  the type to test
+         * @return true if type is an Enum
+         */
+        private static boolean isEnum(TypeMirror type) {
+            if (!(type instanceof DeclaredType)) {
+                return false;
+            }
+
+            return ((DeclaredType) type).asElement().getKind() == ElementKind.ENUM;
+        }
+
+        /**
+         * Compare the type with the expected class
+         * @param type      the type to test
+         * @param expected  the expected type
+         * @return true if the type matches the expected one
+         */
+        private static boolean is(TypeMirror type, Class<?> expected) {
+            if (type instanceof PrimitiveType) {
+                return type.getKind() == kind(expected);
+            }
+
+            if (!(type instanceof DeclaredType)) {
+                return false;
+            }
+
+            Element element = ((DeclaredType) type).asElement();
+            return ((TypeElement) element).getQualifiedName().contentEquals(expected.getName());
+        }
+
+        public static TypeKind kind(Class<?> type) {
+            switch (type.getName()) {
+                case "boolean":
+                    return TypeKind.BOOLEAN;
+                case "byte":
+                    return TypeKind.BYTE;
+                case "short":
+                    return TypeKind.SHORT;
+                case "int":
+                    return TypeKind.INT;
+                case "long":
+                    return TypeKind.LONG;
+                case "float":
+                    return TypeKind.FLOAT;
+                case "double":
+                    return TypeKind.DOUBLE;
+                case "char":
+                    return TypeKind.CHAR;
+                case "void":
+                    return TypeKind.VOID;
+                default:
+                    return TypeKind.DECLARED;
+            }
+        }
+    }
+}

--- a/gravitee-plugin-annotation-processors/src/main/resources/templates/evalClass.mustache
+++ b/gravitee-plugin-annotation-processors/src/main/resources/templates/evalClass.mustache
@@ -1,0 +1,4 @@
+
+        //{{className}} section begin
+        if({{evaluatedConfigurationName}} != null) {
+            currentAttributePrefix = attributePrefix.concat("{{attributeSuffix}}");

--- a/gravitee-plugin-annotation-processors/src/main/resources/templates/evalClose.mustache
+++ b/gravitee-plugin-annotation-processors/src/main/resources/templates/evalClose.mustache
@@ -1,0 +1,3 @@
+
+        }
+        //{{className}} section end

--- a/gravitee-plugin-annotation-processors/src/main/resources/templates/evalField.mustache
+++ b/gravitee-plugin-annotation-processors/src/main/resources/templates/evalField.mustache
@@ -1,0 +1,12 @@
+            //Field {{fieldName}}
+            {{#toEval}}
+            toEval.add(
+            {{/toEval}}
+            {{^toEval}}
+                {{evaluatedConfigurationName}}.{{fieldSetter}}(
+            {{/toEval}}
+                eval{{fieldType}}Property("{{fieldName}}", {{originalConfigurationName}}.{{fieldGetter}}(), {{#fieldClass}}{{fieldClass}}.class,{{/fieldClass}} currentAttributePrefix, ctx)
+            {{#toEval}}
+                .doOnSuccess(value -> {{evaluatedConfigurationName}}.{{fieldSetter}}(value))
+            {{/toEval}}
+            );

--- a/gravitee-plugin-annotation-processors/src/main/resources/templates/evaluatorFooter.mustache
+++ b/gravitee-plugin-annotation-processors/src/main/resources/templates/evaluatorFooter.mustache
@@ -1,0 +1,14 @@
+
+        // Evaluate properties that needs EL, validate evaluatedConf and returns it
+        return Maybe
+            .merge(Flowable.fromIterable(toEval))
+            .ignoreElements()
+            .andThen(Completable.fromRunnable(() -> validateConfiguration(evaluatedConfiguration)))
+            .andThen(Completable.fromRunnable(() ->
+                ctx.setInternalAttribute("{{evaluatedConfigurationName}}-"+this.internalId, evaluatedConfiguration)))
+            .onErrorResumeWith(
+                ctx.interruptWith(new ExecutionFailure(500).message("Invalid configuration").key(FAILURE_CONFIGURATION_INVALID))
+            )
+            .toSingle(() -> evaluatedConfiguration);
+    }
+}

--- a/gravitee-plugin-annotation-processors/src/main/resources/templates/evaluatorHeader.mustache
+++ b/gravitee-plugin-annotation-processors/src/main/resources/templates/evaluatorHeader.mustache
@@ -1,0 +1,192 @@
+/**
+* Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*         http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package {{packageName}};
+
+import io.gravitee.gateway.reactive.api.ExecutionFailure;
+import io.gravitee.gateway.reactive.api.context.ExecutionContext;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import org.hibernate.validator.HibernateValidator;
+import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class {{evaluatorSimpleClassName}} {
+
+    private static final String FAILURE_CONFIGURATION_INVALID = "FAILURE_CONFIGURATION_INVALID";
+
+    private final Logger logger = LoggerFactory.getLogger({{evaluatorSimpleClassName}}.class);
+
+    private final {{simpleClassName}} configuration;
+
+    private static final Validator validator;
+
+    private final String attributePrefix = "{{attributePrefix}}";
+
+    private final String internalId;
+
+    static {
+        ValidatorFactory factory = Validation.byProvider(HibernateValidator.class).configure()
+            .messageInterpolator(new ParameterMessageInterpolator()).buildValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    public {{evaluatorSimpleClassName}} (
+        {{simpleClassName}} configuration)
+    {
+        this.configuration = configuration;
+        this.internalId = UUID.randomUUID().toString();
+    }
+
+    // Utility methods
+    private String buildAttributeName(String attributePrefix, String name) {
+        return attributePrefix.concat(".").concat(name);
+    }
+
+    private Maybe<String> evalStringProperty(String name, String value, String attributePrefix, ExecutionContext ctx) {
+        //First check attributes
+        String attribute = ctx.getAttribute(buildAttributeName(attributePrefix, name));
+        if (attribute != null) {
+            //If a value is found for this attribute, override the original value with it
+            value = attribute;
+        }
+
+        //Then check EL
+        return ctx.getTemplateEngine().eval(value, String.class);
+    }
+
+    private <T extends Enum<T>> T evalEnumProperty(String name, T value, Class<T> enumClass, String attributePrefix, ExecutionContext ctx) {
+        String attribute = ctx.getAttribute(buildAttributeName(attributePrefix, name));
+        if (attribute != null) {
+            return T.valueOf(enumClass, attribute);
+        }
+        return value;
+    }
+
+    private Integer evalIntegerProperty(String name, int value, String attributePrefix, ExecutionContext ctx) {
+        Integer attribute = ctx.getAttribute(buildAttributeName(attributePrefix, name));
+        if (attribute != null) {
+            return attribute;
+        }
+        return value;
+    }
+
+    private Long evalLongProperty(String name, long value, String attributePrefix, ExecutionContext ctx) {
+        Long attribute = ctx.getAttribute(buildAttributeName(attributePrefix, name));
+        if (attribute != null) {
+            return attribute;
+        }
+        return value;
+    }
+
+    private boolean evalBooleanProperty(String name, boolean value, String attributePrefix, ExecutionContext ctx) {
+        Object attribute = ctx.getAttribute(buildAttributeName(attributePrefix, name));
+        if (attribute != null) {
+            return (boolean) attribute;
+        }
+        return value;
+    }
+
+    private <T> Set<T> evalSetProperty(String name, Set<T> value, String attributePrefix, ExecutionContext ctx) {
+        //Try to get a Set and if it fails try to get a String and split it
+        try {
+            Set<T> attribute = ctx.getAttribute(buildAttributeName(attributePrefix, name));
+            if (attribute != null) {
+                return attribute;
+            }
+        } catch (ClassCastException cce) {
+            List<T> attribute = ctx.getAttributeAsList(buildAttributeName(attributePrefix, name));
+            if(attribute != null) {
+                return Set.copyOf(attribute);
+            }
+        }
+
+        return value;
+    }
+
+    private <T> List<T> evalListProperty(String name, List<T> value, String attributePrefix, ExecutionContext ctx) {
+        List<T> attribute = ctx.getAttributeAsList(buildAttributeName(attributePrefix, name));
+        if (attribute != null) {
+            return attribute;
+        }
+
+        return value;
+    }
+
+    private <T> void validateConfiguration(T configuration) {
+        Set<ConstraintViolation<T>> constraintViolations = validator.validate(configuration);
+
+        if (!constraintViolations.isEmpty()) {
+            StringBuilder exceptionMessage = new StringBuilder(constraintViolations.size() + " constraint violations found : ");
+            constraintViolations.forEach(violation ->
+                exceptionMessage
+                    .append("[attribute[")
+                    .append(violation.getPropertyPath())
+                    .append("] reason[")
+                    .append(violation.getMessage())
+                    .append("]]")
+            );
+
+            //LOG
+            logger.error(exceptionMessage.toString());
+
+            //Throw exception with info
+            throw new IllegalStateException(exceptionMessage.toString());
+        }
+    }
+
+    /**
+    * Blocking eval method (see {@link #eval(ExecutionContext)} Eval})
+    * <b>Caution when using this method if the evaluation involves EL expressions that trigger blocking fetches</b>
+    * @param ctx the current context
+    * @return configuration with all dynamic configuration parameters updated
+    */
+    public {{simpleClassName}} evalNow(ExecutionContext ctx) {
+        return eval(ctx).blockingGet();
+    }
+
+    /**
+    * Evaluates the configuration using the context to update parameters using attributes or EL
+    * and stores it as an internal attributes to avoid multiple evaluation
+    * @param ctx the current context
+    * @return configuration with all dynamic configuration parameters updated
+    */
+    public Single<{{simpleClassName}}> eval(ExecutionContext ctx) {
+
+        //First check if the configuration has not been already evaluated
+        {{simpleClassName}} evaluatedConf = ctx.getInternalAttribute("{{evaluatedConfigurationName}}-"+this.internalId);
+        if(evaluatedConf != null) {
+            return Single.just(evaluatedConf);
+        }
+
+        {{simpleClassName}} evaluatedConfiguration = new {{simpleClassName}}();
+        String currentAttributePrefix = attributePrefix;
+
+        List<Maybe<String>> toEval = new ArrayList<>();
+

--- a/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/gateway/reactive/api/ExecutionFailure.java
+++ b/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/gateway/reactive/api/ExecutionFailure.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.api;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class ExecutionFailure {
+
+    private String message;
+
+    public ExecutionFailure(int statusCode) {}
+
+    public ExecutionFailure message(String message) {
+        this.message = message;
+        return this;
+    }
+
+    public String message() {
+        return message;
+    }
+
+    public ExecutionFailure key(String key) {
+        return this;
+    }
+}

--- a/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/gateway/reactive/api/context/ExecutionContext.java
+++ b/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/gateway/reactive/api/context/ExecutionContext.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.api.context;
+
+import io.gravitee.gateway.reactive.api.ExecutionFailure;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Maybe;
+import java.util.List;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class ExecutionContext {
+
+    public TemplateEngine getTemplateEngine() {
+        return null;
+    }
+
+    public <T> T getAttribute(String attribute) {
+        return null;
+    }
+
+    public <T> List<T> getAttributeAsList(String name) {
+        return null;
+    }
+
+    public void setInternalAttribute(String var1, Object var2) {}
+
+    public <T> T getInternalAttribute(String attribute) {
+        return null;
+    }
+
+    public Completable interruptWith(final ExecutionFailure failure) {
+        return Completable.complete();
+    }
+
+    public static class TemplateEngine {
+
+        public <T> Maybe<T> eval(String expression, Class<T> clazz) {
+            return Maybe.just((T) expression);
+        }
+    }
+}

--- a/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/ConfigurationEvaluatorGeneratedTest.java
+++ b/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/ConfigurationEvaluatorGeneratedTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.annotation.processor;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.gateway.reactive.api.ExecutionFailure;
+import io.gravitee.gateway.reactive.api.context.ExecutionContext;
+import io.gravitee.plugin.annotation.processor.result.SecurityProtocol;
+import io.gravitee.plugin.annotation.processor.result.TestConfiguration;
+import io.gravitee.plugin.annotation.processor.result.TestConfigurationEvaluator;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.observers.TestObserver;
+import java.util.List;
+import java.util.Set;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ConfigurationEvaluatorGeneratedTest {
+
+    TestConfigurationEvaluator evaluator;
+
+    @Mock
+    ExecutionContext context;
+
+    @Mock
+    ExecutionContext.TemplateEngine templateEngine;
+
+    @Before
+    public void before() {
+        TestConfiguration configuration = new TestConfiguration();
+        configuration.getConsumer().setEnabled(true);
+        configuration.getConsumer().setAutoOffsetReset("none");
+        evaluator = new TestConfigurationEvaluator(configuration);
+
+        when(context.getTemplateEngine()).thenReturn(templateEngine);
+
+        when(context.interruptWith(any()))
+            .thenAnswer(invocation ->
+                Completable.defer(() ->
+                    Completable.error(new IllegalStateException(((ExecutionFailure) invocation.getArgument(0)).message()))
+                )
+            );
+    }
+
+    @Test
+    public void should_interrupt_with_error_on_validation() {
+        when(templateEngine.eval("none", String.class)).thenReturn(Maybe.just("result"));
+
+        TestObserver<TestConfiguration> testObserver = evaluator.eval(context).test();
+
+        testObserver.assertError(throwable -> {
+            assertThat(throwable).isInstanceOf(IllegalStateException.class);
+            assertThat(throwable.getMessage()).isEqualTo("Invalid configuration");
+            return true;
+        });
+    }
+
+    @Test
+    public void should_return_evaluated_configuration() {
+        when(templateEngine.eval("none", String.class)).thenReturn(Maybe.just("latest"));
+        when(context.getAttribute("gravitee.attributes.endpoint.test.protocol")).thenReturn("SSL");
+        when(context.getAttribute("gravitee.attributes.endpoint.test.consumer.topics")).thenReturn("topic1,topic2");
+        when(context.getAttributeAsList("gravitee.attributes.endpoint.test.consumer.topics")).thenReturn(List.of("topic1", "topic2"));
+
+        TestObserver<TestConfiguration> testObserver = evaluator.eval(context).test();
+
+        testObserver.assertComplete();
+
+        testObserver.assertValue(testConfiguration -> {
+            assertThat(testConfiguration.getConsumer().getAutoOffsetReset()).isEqualTo("latest");
+            assertThat(testConfiguration.getProtocol()).isEqualTo(SecurityProtocol.SSL);
+            assertThat(testConfiguration.getConsumer().getTopics()).isEqualTo(Set.of("topic1", "topic2"));
+            return true;
+        });
+
+        verify(context).getAttributeAsList("gravitee.attributes.endpoint.test.consumer.topics");
+        verify(context).setInternalAttribute(anyString(), any(TestConfiguration.class));
+    }
+
+    @Test
+    public void should_return_evaluated_configuration_from_internal_attribute() {
+        TestConfiguration configuration = new TestConfiguration();
+        configuration.getConsumer().setAutoOffsetReset("earliest");
+        when(context.getInternalAttribute(anyString())).thenReturn(configuration);
+
+        TestObserver<TestConfiguration> testObserver = evaluator.eval(context).test();
+
+        testObserver.assertComplete();
+
+        testObserver.assertValue(testConfiguration -> {
+            assertThat(testConfiguration.getConsumer().getAutoOffsetReset()).isEqualTo("earliest");
+            return true;
+        });
+
+        verify(context, times(0)).setInternalAttribute(anyString(), any(TestConfiguration.class));
+    }
+}

--- a/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/ConfigurationEvaluatorProcessorTest.java
+++ b/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/ConfigurationEvaluatorProcessorTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.annotation.processor;
+
+import static com.google.testing.compile.Compiler.javac;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableList;
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.CompilationSubject;
+import com.google.testing.compile.JavaFileObjectSubject;
+import com.google.testing.compile.JavaFileObjects;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+import javax.tools.JavaFileObject;
+import org.junit.Test;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class ConfigurationEvaluatorProcessorTest {
+
+    private static final JavaFileObject RESULT = JavaFileObjects.forResource("test/TestConfigurationEvaluator.java");
+
+    @Test
+    public void shouldGenerateTheExpectedResultFile() throws IOException {
+        ConfigurationEvaluatorProcessor processor = new ConfigurationEvaluatorProcessor();
+
+        JavaFileObject test = JavaFileObjects.forSourceString(
+            "TestConfiguration",
+            readJavaCodeFromFile("src/test/java/io/gravitee/plugin/annotation/processor/result/TestConfiguration.java")
+        );
+
+        // Run
+        Compilation compilation = javac().withProcessors(processor).compile(test);
+        CompilationSubject.assertThat(compilation).succeeded();
+
+        // Verify
+        ImmutableList<JavaFileObject> generatedFiles = compilation.generatedFiles();
+        //assertEquals(11, generatedFiles.size());
+
+        Optional<JavaFileObject> generatedSourceFile = generatedFiles
+            .stream()
+            .filter(generatedFile -> generatedFile.getKind() == JavaFileObject.Kind.SOURCE)
+            .findFirst();
+
+        assertTrue(generatedSourceFile.isPresent());
+        JavaFileObjectSubject.assertThat(generatedSourceFile.get()).hasSourceEquivalentTo(RESULT);
+    }
+
+    private static String readJavaCodeFromFile(String filePath) throws IOException {
+        Path path = Paths.get(filePath);
+        byte[] bytes = Files.readAllBytes(path);
+        return new String(bytes, StandardCharsets.UTF_8);
+    }
+}

--- a/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/result/KeyStore.java
+++ b/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/result/KeyStore.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.annotation.processor.result;
+
+public class KeyStore {
+
+    private String key;
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+}

--- a/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/result/SecurityConfiguration.java
+++ b/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/result/SecurityConfiguration.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.annotation.processor.result;
+
+public class SecurityConfiguration {
+
+    private String property;
+
+    public String getProperty() {
+        return property;
+    }
+
+    public void setProperty(String property) {
+        this.property = property;
+    }
+}

--- a/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/result/SecurityProtocol.java
+++ b/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/result/SecurityProtocol.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.annotation.processor.result;
+
+public enum SecurityProtocol {
+    /**
+     * No authentication no encryption
+     */
+    PLAINTEXT("PLAINTEXT"),
+    /**
+     * SASL authentication with no TLS
+     */
+    SASL_PLAINTEXT("SASL_PLAINTEXT"),
+    /**
+     * SASL authentication with TLS/SSL encryption
+     */
+    SASL_SSL("SASL_SSL"),
+    /**
+     * SSL for both encryption and authentication without SASL
+     */
+    SSL("SSL");
+
+    private SecurityProtocol(String value) {
+        this.value = value;
+    }
+
+    private final String value;
+}

--- a/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/result/Ssl.java
+++ b/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/result/Ssl.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.annotation.processor.result;
+
+public class Ssl {
+
+    private KeyStore keyStore;
+
+    private long timeout;
+
+    public KeyStore getKeyStore() {
+        return keyStore;
+    }
+
+    public void setKeyStore(KeyStore keyStore) {
+        this.keyStore = keyStore;
+    }
+
+    public long getTimeout() {
+        return timeout;
+    }
+
+    public void setTimeout(long timeout) {
+        this.timeout = timeout;
+    }
+}

--- a/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/result/TestConfiguration.java
+++ b/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/result/TestConfiguration.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+package io.gravitee.plugin.annotation.processor.result;
+
+import io.gravitee.plugin.annotation.ConfigurationEvaluator;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import java.util.Set;
+
+@ConfigurationEvaluator(attributePrefix = "gravitee.attributes.endpoint.test")
+public class TestConfiguration {
+
+    //Enum
+    private SecurityProtocol protocol = SecurityProtocol.PLAINTEXT;
+
+    //Object
+    private Ssl ssl;
+
+    @Valid
+    private SecurityConfiguration security;
+
+    //Inner class
+    @Valid
+    private Consumer consumer = new Consumer();
+
+    public TestConfiguration(SecurityProtocol protocol, Ssl ssl, SecurityConfiguration security, Consumer consumer) {
+        this.protocol = protocol;
+        this.ssl = ssl;
+        this.security = security;
+        this.consumer = consumer;
+    }
+
+    public TestConfiguration() {}
+
+    public SecurityProtocol getProtocol() {
+        return protocol;
+    }
+
+    public void setProtocol(SecurityProtocol protocol) {
+        this.protocol = protocol;
+    }
+
+    public Ssl getSsl() {
+        return ssl;
+    }
+
+    public void setSsl(Ssl ssl) {
+        this.ssl = ssl;
+    }
+
+    public TestConfiguration.Consumer getConsumer() {
+        return consumer;
+    }
+
+    public void setConsumer(TestConfiguration.Consumer consumer) {
+        this.consumer = consumer;
+    }
+
+    public SecurityConfiguration getSecurity() {
+        return this.security;
+    }
+
+    public void setSecurity(SecurityConfiguration security) {
+        this.security = security;
+    }
+
+    private static TestConfiguration.Consumer $default$consumer() {
+        return new Consumer();
+    }
+
+    private static SecurityConfiguration $default$security() {
+        return new SecurityConfiguration();
+    }
+
+    private static Ssl $default$ssl() {
+        return new Ssl();
+    }
+
+    public static TestConfigurationBuilder builder() {
+        return new TestConfigurationBuilder();
+    }
+
+    public static class Consumer {
+
+        private boolean enabled;
+
+        @Pattern(regexp = "latest|earliest|none")
+        private String autoOffsetReset = "latest";
+
+        @Size(min = 1)
+        private Set<String> topics;
+
+        private TrustStore trustStore;
+
+        private List<String> attributes;
+
+        public Consumer(boolean enabled, Set<String> topics, String autoOffsetReset, List<String> attributes) {
+            this.enabled = enabled;
+            this.topics = topics;
+            this.autoOffsetReset = autoOffsetReset;
+            this.attributes = attributes;
+        }
+
+        public Consumer() {}
+
+        public boolean isEnabled() {
+            return this.enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public String getAutoOffsetReset() {
+            return this.autoOffsetReset;
+        }
+
+        public void setAutoOffsetReset(String autoOffsetReset) {
+            this.autoOffsetReset = autoOffsetReset;
+        }
+
+        public Set<String> getTopics() {
+            return this.topics;
+        }
+
+        public void setTopics(Set<String> topics) {
+            this.topics = topics;
+        }
+
+        public TrustStore getTrustStore() {
+            return trustStore;
+        }
+
+        public void setTrustStore(TrustStore trustStore) {
+            this.trustStore = trustStore;
+        }
+
+        public void setAttributes(List<String> attributes) {
+            this.attributes = attributes;
+        }
+
+        public List<String> getAttributes() {
+            return attributes;
+        }
+
+        public static ConsumerBuilder builder() {
+            return new ConsumerBuilder();
+        }
+
+        @Pattern(regexp = "latest|earliest|none")
+        private static String $default$autoOffsetReset() {
+            return "latest";
+        }
+
+        public static class ConsumerBuilder {
+
+            private boolean enabled;
+
+            @Size(min = 1)
+            private Set<String> topics;
+
+            @Pattern(regexp = "latest|earliest|none")
+            private String autoOffsetReset$value;
+
+            private boolean autoOffsetReset$set;
+
+            private List<String> attributes;
+
+            ConsumerBuilder() {}
+
+            public ConsumerBuilder enabled(boolean enabled) {
+                this.enabled = enabled;
+                return this;
+            }
+
+            public ConsumerBuilder topics(@Size(min = 1) Set<String> topics) {
+                this.topics = topics;
+                return this;
+            }
+
+            public ConsumerBuilder attributes(List<String> attributes) {
+                this.attributes = attributes;
+                return this;
+            }
+
+            public ConsumerBuilder autoOffsetReset(@Pattern(regexp = "latest|earliest|none") String autoOffsetReset) {
+                this.autoOffsetReset$value = autoOffsetReset;
+                this.autoOffsetReset$set = true;
+                return this;
+            }
+
+            public Consumer build() {
+                String autoOffsetReset$value = this.autoOffsetReset$value;
+                if (!this.autoOffsetReset$set) {
+                    autoOffsetReset$value = TestConfiguration.Consumer.$default$autoOffsetReset();
+                }
+                return new Consumer(this.enabled, this.topics, autoOffsetReset$value, this.attributes);
+            }
+
+            public String toString() {
+                return (
+                    "ExampleConfiguration.Consumer.ConsumerBuilder(enabled=" +
+                    this.enabled +
+                    ", topics=" +
+                    this.topics +
+                    ", autoOffsetReset$value=" +
+                    this.autoOffsetReset$value +
+                    ", attributes=" +
+                    this.attributes +
+                    ")"
+                );
+            }
+        }
+    }
+
+    public static class TestConfigurationBuilder {
+
+        private Consumer consumer$value;
+        private boolean consumer$set;
+        private SecurityConfiguration security$value;
+        private boolean security$set;
+
+        private SecurityProtocol protocol = SecurityProtocol.PLAINTEXT;
+        private Ssl ssl$value;
+        private boolean ssl$set;
+
+        TestConfigurationBuilder() {}
+
+        public TestConfigurationBuilder consumer(Consumer consumer) {
+            this.consumer$value = consumer;
+            this.consumer$set = true;
+            return this;
+        }
+
+        public TestConfigurationBuilder ssl(Ssl ssl) {
+            this.ssl$value = ssl;
+            this.ssl$set = true;
+            return this;
+        }
+
+        public TestConfigurationBuilder protocol(SecurityProtocol protocol) {
+            this.protocol = protocol;
+            return this;
+        }
+
+        public TestConfigurationBuilder security(SecurityConfiguration security) {
+            this.security$value = security;
+            this.security$set = true;
+            return this;
+        }
+
+        public TestConfiguration build() {
+            TestConfiguration.Consumer consumer$value = this.consumer$value;
+            if (!this.consumer$set) {
+                consumer$value = TestConfiguration.$default$consumer();
+            }
+            SecurityConfiguration security$value = this.security$value;
+            if (!this.security$set) {
+                security$value = TestConfiguration.$default$security();
+            }
+
+            Ssl ssl$value = this.ssl$value;
+            if (!this.ssl$set) {
+                ssl$value = TestConfiguration.$default$ssl();
+            }
+            return new TestConfiguration(protocol, ssl$value, security$value, consumer$value);
+        }
+
+        public String toString() {
+            return (
+                "ExampleConfiguration.TestConfigurationBuilder(consumer$value=" +
+                this.consumer$value +
+                ", security$value=" +
+                this.security$value +
+                ")"
+            );
+        }
+    }
+}

--- a/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/result/TrustStore.java
+++ b/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/result/TrustStore.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.annotation.processor.result;
+
+public class TrustStore {
+
+    private String key;
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+}

--- a/gravitee-plugin-annotation-processors/src/test/resources/test/TestConfigurationEvaluator.java
+++ b/gravitee-plugin-annotation-processors/src/test/resources/test/TestConfigurationEvaluator.java
@@ -1,0 +1,270 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.annotation.processor.result;
+
+import io.gravitee.gateway.reactive.api.ExecutionFailure;
+import io.gravitee.gateway.reactive.api.context.ExecutionContext;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.hibernate.validator.HibernateValidator;
+import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TestConfigurationEvaluator {
+
+    private static final String FAILURE_CONFIGURATION_INVALID = "FAILURE_CONFIGURATION_INVALID";
+
+    private final Logger logger = LoggerFactory.getLogger(TestConfigurationEvaluator.class);
+
+    private final TestConfiguration configuration;
+
+    private static final Validator validator;
+
+    private final String attributePrefix = "gravitee.attributes.endpoint.test";
+
+    private final String internalId;
+
+    static {
+        ValidatorFactory factory = Validation
+            .byProvider(HibernateValidator.class)
+            .configure()
+            .messageInterpolator(new ParameterMessageInterpolator())
+            .buildValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    public TestConfigurationEvaluator(TestConfiguration configuration) {
+        this.configuration = configuration;
+        this.internalId = UUID.randomUUID().toString();
+    }
+
+    // Utility methods
+    private String buildAttributeName(String attributePrefix, String name) {
+        return attributePrefix.concat(".").concat(name);
+    }
+
+    private Maybe<String> evalStringProperty(String name, String value, String attributePrefix, ExecutionContext ctx) {
+        //First check attributes
+        String attribute = ctx.getAttribute(buildAttributeName(attributePrefix, name));
+        if (attribute != null) {
+            //If a value is found for this attribute, override the original value with it
+            value = attribute;
+        }
+
+        //Then check EL
+        return ctx.getTemplateEngine().eval(value, String.class);
+    }
+
+    private <T extends Enum<T>> T evalEnumProperty(String name, T value, Class<T> enumClass, String attributePrefix, ExecutionContext ctx) {
+        String attribute = ctx.getAttribute(buildAttributeName(attributePrefix, name));
+        if (attribute != null) {
+            return T.valueOf(enumClass, attribute);
+        }
+        return value;
+    }
+
+    private Integer evalIntegerProperty(String name, int value, String attributePrefix, ExecutionContext ctx) {
+        Integer attribute = ctx.getAttribute(buildAttributeName(attributePrefix, name));
+        if (attribute != null) {
+            return attribute;
+        }
+        return value;
+    }
+
+    private Long evalLongProperty(String name, long value, String attributePrefix, ExecutionContext ctx) {
+        Long attribute = ctx.getAttribute(buildAttributeName(attributePrefix, name));
+        if (attribute != null) {
+            return attribute;
+        }
+        return value;
+    }
+
+    private boolean evalBooleanProperty(String name, boolean value, String attributePrefix, ExecutionContext ctx) {
+        Object attribute = ctx.getAttribute(buildAttributeName(attributePrefix, name));
+        if (attribute != null) {
+            return (boolean) attribute;
+        }
+        return value;
+    }
+
+    private <T> Set<T> evalSetProperty(String name, Set<T> value, String attributePrefix, ExecutionContext ctx) {
+        //Try to get a Set and if it fails try to get a String and split it
+        try {
+            Set<T> attribute = ctx.getAttribute(buildAttributeName(attributePrefix, name));
+            if (attribute != null) {
+                return attribute;
+            }
+        } catch (ClassCastException cce) {
+            List<T> attribute = ctx.getAttributeAsList(buildAttributeName(attributePrefix, name));
+            if (attribute != null) {
+                return Set.copyOf(attribute);
+            }
+        }
+
+        return value;
+    }
+
+    private <T> List<T> evalListProperty(String name, List<T> value, String attributePrefix, ExecutionContext ctx) {
+        List<T> attribute = ctx.getAttributeAsList(buildAttributeName(attributePrefix, name));
+        if (attribute != null) {
+            return attribute;
+        }
+
+        return value;
+    }
+
+    private <T> void validateConfiguration(T configuration) {
+        Set<ConstraintViolation<T>> constraintViolations = validator.validate(configuration);
+
+        if (!constraintViolations.isEmpty()) {
+            StringBuilder exceptionMessage = new StringBuilder(constraintViolations.size() + " constraint violations found : ");
+            constraintViolations.forEach(violation ->
+                exceptionMessage
+                    .append("[attribute[")
+                    .append(violation.getPropertyPath())
+                    .append("] reason[")
+                    .append(violation.getMessage())
+                    .append("]]")
+            );
+
+            //LOG
+            logger.error(exceptionMessage.toString());
+
+            //Throw exception with info
+            throw new IllegalStateException(exceptionMessage.toString());
+        }
+    }
+
+    public TestConfiguration evalNow(ExecutionContext ctx) {
+        return eval(ctx).blockingGet();
+    }
+
+    public Single<TestConfiguration> eval(ExecutionContext ctx) {
+        //First check if the configuration has not been already evaluated
+        TestConfiguration evaluatedConf = ctx.getInternalAttribute("testConfiguration-" + this.internalId);
+        if (evaluatedConf != null) {
+            return Single.just(evaluatedConf);
+        }
+
+        TestConfiguration evaluatedConfiguration = new TestConfiguration();
+        String currentAttributePrefix = attributePrefix;
+
+        List<Maybe<String>> toEval = new ArrayList<>();
+
+        //Field protocol
+        evaluatedConfiguration.setProtocol(
+            evalEnumProperty(
+                "protocol",
+                configuration.getProtocol(),
+                io.gravitee.plugin.annotation.processor.result.SecurityProtocol.class,
+                currentAttributePrefix,
+                ctx
+            )
+        );
+
+        //Consumer section begin
+        if (evaluatedConfiguration.getConsumer() != null) {
+            currentAttributePrefix = attributePrefix.concat(".consumer");
+            //Field enabled
+            evaluatedConfiguration
+                .getConsumer()
+                .setEnabled(evalBooleanProperty("enabled", configuration.getConsumer().isEnabled(), currentAttributePrefix, ctx));
+            //Field autoOffsetReset
+            toEval.add(
+                evalStringProperty("autoOffsetReset", configuration.getConsumer().getAutoOffsetReset(), currentAttributePrefix, ctx)
+                    .doOnSuccess(value -> evaluatedConfiguration.getConsumer().setAutoOffsetReset(value))
+            );
+            //Field topics
+            evaluatedConfiguration
+                .getConsumer()
+                .setTopics(evalSetProperty("topics", configuration.getConsumer().getTopics(), currentAttributePrefix, ctx));
+            //Field attributes
+            evaluatedConfiguration
+                .getConsumer()
+                .setAttributes(evalListProperty("attributes", configuration.getConsumer().getAttributes(), currentAttributePrefix, ctx));
+
+            //trustStore section begin
+            if (evaluatedConfiguration.getConsumer().getTrustStore() != null) {
+                currentAttributePrefix = attributePrefix.concat(".consumer.trustStore");
+                //Field key
+                toEval.add(
+                    evalStringProperty("key", configuration.getConsumer().getTrustStore().getKey(), currentAttributePrefix, ctx)
+                        .doOnSuccess(value -> evaluatedConfiguration.getConsumer().getTrustStore().setKey(value))
+                );
+            }
+            //trustStore section end
+
+        }
+        //Consumer section end
+
+        //ssl section begin
+        if (evaluatedConfiguration.getSsl() != null) {
+            currentAttributePrefix = attributePrefix.concat(".ssl");
+            //Field timeout
+            evaluatedConfiguration
+                .getSsl()
+                .setTimeout(evalLongProperty("timeout", configuration.getSsl().getTimeout(), currentAttributePrefix, ctx));
+
+            //keyStore section begin
+            if (evaluatedConfiguration.getSsl().getKeyStore() != null) {
+                currentAttributePrefix = attributePrefix.concat(".ssl.keyStore");
+                //Field key
+                toEval.add(
+                    evalStringProperty("key", configuration.getSsl().getKeyStore().getKey(), currentAttributePrefix, ctx)
+                        .doOnSuccess(value -> evaluatedConfiguration.getSsl().getKeyStore().setKey(value))
+                );
+            }
+            //keyStore section end
+
+        }
+        //ssl section end
+
+        //security section begin
+        if (evaluatedConfiguration.getSecurity() != null) {
+            currentAttributePrefix = attributePrefix.concat(".security");
+            //Field property
+            toEval.add(
+                evalStringProperty("property", configuration.getSecurity().getProperty(), currentAttributePrefix, ctx)
+                    .doOnSuccess(value -> evaluatedConfiguration.getSecurity().setProperty(value))
+            );
+        }
+        //security section end
+
+        // Evaluate properties that needs EL, validate evaluatedConf and returns it
+        return Maybe
+            .merge(Flowable.fromIterable(toEval))
+            .ignoreElements()
+            .andThen(Completable.fromRunnable(() -> validateConfiguration(evaluatedConfiguration)))
+            .andThen(
+                Completable.fromRunnable(() -> ctx.setInternalAttribute("testConfiguration-" + this.internalId, evaluatedConfiguration))
+            )
+            .onErrorResumeWith(
+                ctx.interruptWith(new ExecutionFailure(500).message("Invalid configuration").key(FAILURE_CONFIGURATION_INVALID))
+            )
+            .toSingle(() -> evaluatedConfiguration);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
         <module>gravitee-plugin-identityprovider</module>
         <module>gravitee-plugin-cockpit</module>
         <module>gravitee-plugin-connector</module>
+        <module>gravitee-plugin-annotation-processors</module>
     </modules>
 
     <dependencyManagement>
@@ -134,6 +135,11 @@
             <dependency>
                 <groupId>io.gravitee.plugin</groupId>
                 <artifactId>gravitee-plugin-identityprovider</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.gravitee.plugin</groupId>
+                <artifactId>gravitee-plugin-annotation-processors</artifactId>
                 <version>${project.version}</version>
             </dependency>
 


### PR DESCRIPTION
…uator for configuration bean of plugin that can be used to handle dynamic conf feature

**Issue**

https://gravitee.atlassian.net/browse/ARCHI-228

**Description**

This PR adds a new module that contains annotation processors. Right now only one is added to manage the dynamic configuration feature for plugin (see jira ticket and slab page : https://gravitee.slab.com/posts/dynamic-entrypoint-and-endpoint-configuration-4redtr84). The README describes how this annotation can be used and what it is doing. The main idea here was to avoid writing the same logic in each plugin where we want this feature to be available, so "just" by adding this annotation, most of the work is done.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.1.0-ARCHI-228-feat-dynamic-conf-add-annotation-processor-to-generate-evaluator-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/plugin/gravitee-plugin/2.1.0-ARCHI-228-feat-dynamic-conf-add-annotation-processor-to-generate-evaluator-SNAPSHOT/gravitee-plugin-2.1.0-ARCHI-228-feat-dynamic-conf-add-annotation-processor-to-generate-evaluator-SNAPSHOT.zip)
  <!-- Version placeholder end -->
