### PR TITLE
fix: PluginEvent ended sent before plugins list in PluginRegistryImpl…

### DIFF
--- a/gravitee-plugin-core/src/main/java/io/gravitee/plugin/core/internal/PluginRegistryImpl.java
+++ b/gravitee-plugin-core/src/main/java/io/gravitee/plugin/core/internal/PluginRegistryImpl.java
@@ -129,12 +129,12 @@ public class PluginRegistryImpl extends AbstractService<PluginRegistry> implemen
                     .doOnNext(plugin -> eventManager.publishEvent(PluginEvent.DEPLOYED, plugin))
                     .cast(Plugin.class)
                     .toList()
-                    .doOnSuccess(list -> {
-                        printPlugins(list);
-                        eventManager.publishEvent(PluginEvent.ENDED, null);
-                    })
+                    .doOnSuccess(PluginRegistryImpl::printPlugins)
                     .blockingGet()
             );
+
+        // Publish the ENDED event when the plugins list is ready
+        eventManager.publishEvent(PluginEvent.ENDED, null);
     }
 
     private Flowable<PluginImpl> loadPluginsFromPath(final String pluginPathAsString) throws IOException {


### PR DESCRIPTION
… ready (prevent cockpit-connector plugin to start)

**Issue**

Fix issue from https://gravitee.atlassian.net/browse/ARCHI-253  

**Description**

The ENDED event was sent before the plugins list in the registry was ready. The eventManager is not asynchronous which means that the event is consume by all listeners before the rest of the code was executed. This prevents the cockpit connector plugin to start properly since its calling the plugins list from the registry while being started (which is done when the ended event is processed).
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.1-fix-ended-event-sent-before-plugin-list-ready-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/plugin/gravitee-plugin/2.0.1-fix-ended-event-sent-before-plugin-list-ready-SNAPSHOT/gravitee-plugin-2.0.1-fix-ended-event-sent-before-plugin-list-ready-SNAPSHOT.zip)
  <!-- Version placeholder end -->
