### PR TITLE
ARCHI-222 secret managers: plugin load ordering update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2.0.3](https://github.com/gravitee-io/gravitee-plugin/compare/2.0.2...2.0.3) (2023-09-14)
+
+
+### Bug Fixes
+
+* bump gravitee-common to 3.3.3 ([3d51cf9](https://github.com/gravitee-io/gravitee-plugin/commit/3d51cf96f086c2c039183a18dceeebce9e015fea))
+
 ## [2.0.2](https://github.com/gravitee-io/gravitee-plugin/compare/2.0.1...2.0.2) (2023-07-28)
 
 

--- a/gravitee-plugin-alert/pom.xml
+++ b/gravitee-plugin-alert/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.plugin</groupId>
         <artifactId>gravitee-plugin</artifactId>
-        <version>2.0.2</version>
+        <version>2.0.3</version>
     </parent>
 
     <artifactId>gravitee-plugin-alert</artifactId>

--- a/gravitee-plugin-api/pom.xml
+++ b/gravitee-plugin-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.plugin</groupId>
         <artifactId>gravitee-plugin</artifactId>
-        <version>2.0.2</version>
+        <version>2.0.3</version>
     </parent>
 
     <artifactId>gravitee-plugin-api</artifactId>

--- a/gravitee-plugin-cockpit/pom.xml
+++ b/gravitee-plugin-cockpit/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>gravitee-plugin</artifactId>
         <groupId>io.gravitee.plugin</groupId>
-        <version>2.0.2</version>
+        <version>2.0.3</version>
     </parent>
 
     <artifactId>gravitee-plugin-cockpit</artifactId>

--- a/gravitee-plugin-connector/pom.xml
+++ b/gravitee-plugin-connector/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.plugin</groupId>
         <artifactId>gravitee-plugin</artifactId>
-        <version>2.0.2</version>
+        <version>2.0.3</version>
     </parent>
 
     <artifactId>gravitee-plugin-connector</artifactId>

--- a/gravitee-plugin-core/pom.xml
+++ b/gravitee-plugin-core/pom.xml
@@ -70,6 +70,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
             <scope>test</scope>

--- a/gravitee-plugin-core/pom.xml
+++ b/gravitee-plugin-core/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.plugin</groupId>
         <artifactId>gravitee-plugin</artifactId>
-        <version>2.0.2</version>
+        <version>2.0.3</version>
     </parent>
 
     <artifactId>gravitee-plugin-core</artifactId>

--- a/gravitee-plugin-core/src/main/java/io/gravitee/plugin/core/spring/PluginConfiguration.java
+++ b/gravitee-plugin-core/src/main/java/io/gravitee/plugin/core/spring/PluginConfiguration.java
@@ -61,8 +61,12 @@ public class PluginConfiguration {
     }
 
     @Bean
-    public PluginEventListener pluginEventListener(Collection<PluginHandler> pluginHandlers, EventManager eventManager) {
-        return new PluginEventListener(pluginHandlers, eventManager);
+    public PluginEventListener pluginEventListener(
+        Collection<PluginHandler> pluginHandlers,
+        EventManager eventManager,
+        Environment environment
+    ) {
+        return new PluginEventListener(pluginHandlers, eventManager, environment);
     }
 
     @Bean

--- a/gravitee-plugin-fetcher/pom.xml
+++ b/gravitee-plugin-fetcher/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.plugin</groupId>
         <artifactId>gravitee-plugin</artifactId>
-        <version>2.0.2</version>
+        <version>2.0.3</version>
     </parent>
 
     <artifactId>gravitee-plugin-fetcher</artifactId>

--- a/gravitee-plugin-identityprovider/pom.xml
+++ b/gravitee-plugin-identityprovider/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.plugin</groupId>
         <artifactId>gravitee-plugin</artifactId>
-        <version>2.0.2</version>
+        <version>2.0.3</version>
     </parent>
 
     <artifactId>gravitee-plugin-identityprovider</artifactId>

--- a/gravitee-plugin-notifier/pom.xml
+++ b/gravitee-plugin-notifier/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.plugin</groupId>
         <artifactId>gravitee-plugin</artifactId>
-        <version>2.0.2</version>
+        <version>2.0.3</version>
     </parent>
 
     <artifactId>gravitee-plugin-notifier</artifactId>

--- a/gravitee-plugin-policy/pom.xml
+++ b/gravitee-plugin-policy/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.plugin</groupId>
         <artifactId>gravitee-plugin</artifactId>
-        <version>2.0.2</version>
+        <version>2.0.3</version>
     </parent>
 
     <artifactId>gravitee-plugin-policy</artifactId>

--- a/gravitee-plugin-repository/pom.xml
+++ b/gravitee-plugin-repository/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.plugin</groupId>
         <artifactId>gravitee-plugin</artifactId>
-        <version>2.0.2</version>
+        <version>2.0.3</version>
     </parent>
 
     <artifactId>gravitee-plugin-repository</artifactId>

--- a/gravitee-plugin-resource/pom.xml
+++ b/gravitee-plugin-resource/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.plugin</groupId>
         <artifactId>gravitee-plugin</artifactId>
-        <version>2.0.2</version>
+        <version>2.0.3</version>
     </parent>
 
     <artifactId>gravitee-plugin-resource</artifactId>

--- a/gravitee-plugin-service-discovery/pom.xml
+++ b/gravitee-plugin-service-discovery/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.plugin</groupId>
         <artifactId>gravitee-plugin</artifactId>
-        <version>2.0.2</version>
+        <version>2.0.3</version>
     </parent>
 
     <artifactId>gravitee-plugin-service-discovery</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
     <properties>
         <gravitee-bom.version>6.0.1</gravitee-bom.version>
-        <gravitee-common.version>2.1.1</gravitee-common.version>
+        <gravitee-common.version>3.3.3</gravitee-common.version>
         <gravitee-gateway-api.version>2.1.0</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>io.gravitee.plugin</groupId>
     <artifactId>gravitee-plugin</artifactId>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
     <packaging>pom</packaging>
     <name>Gravitee.io APIM - Plugin</name>
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/ARCHI-222

**Description**

Setup secret-provider to be first in the loading order
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.1.0-archi-222-secret-managers-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/plugin/gravitee-plugin/2.1.0-archi-222-secret-managers-SNAPSHOT/gravitee-plugin-2.1.0-archi-222-secret-managers-SNAPSHOT.zip)
  <!-- Version placeholder end -->
