### PR TITLE
fix: bump gravitee-common to 3.3.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
     <properties>
         <gravitee-bom.version>6.0.1</gravitee-bom.version>
-        <gravitee-common.version>2.1.1</gravitee-common.version>
+        <gravitee-common.version>3.3.3</gravitee-common.version>
         <gravitee-gateway-api.version>2.1.0</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>


### PR DESCRIPTION
see https://github.com/gravitee-io/gravitee-common/pull/101

This is to avoid this error when apim starts

```
{
    "timestamp": "2023-09-13T15:40:54.667Z",
    "level": "ERROR",
    "thread": "graviteeio-node",
    "logger": "io.gravitee.plugin.core.internal.PluginContextFactoryImpl",
    "message": "Unable to refresh plugin context",
    "context": "default",
    "exception": "[...] Caused by: java.lang.NoClassDefFoundError: io/gravitee/common/templating/FreeMarkerComponent [...]",
}

```
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.3-fix-bump-gravitee-common-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/plugin/gravitee-plugin/2.0.3-fix-bump-gravitee-common-SNAPSHOT/gravitee-plugin-2.0.3-fix-bump-gravitee-common-SNAPSHOT.zip)
  <!-- Version placeholder end -->
