### PR TITLE
fix: allow constant in configuration bean (ConfigurationEvaluator an…

### DIFF
--- a/gravitee-plugin-annotation-processors/src/main/java/io/gravitee/plugin/annotation/processor/ConfigurationEvaluatorProcessor.java
+++ b/gravitee-plugin-annotation-processors/src/main/java/io/gravitee/plugin/annotation/processor/ConfigurationEvaluatorProcessor.java
@@ -38,6 +38,7 @@ import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
@@ -161,7 +162,9 @@ public class ConfigurationEvaluatorProcessor extends AbstractProcessor {
         List<VariableElement> fields = elementUtils
             .getAllMembers(currentElement)
             .stream()
-            .filter(element -> element.getKind() == ElementKind.FIELD && !element.getSimpleName().toString().contains("Builder"))
+            .filter(element ->
+                element.getKind() == ElementKind.FIELD && !element.getSimpleName().toString().contains("Builder") && !isConstant(element)
+            )
             .map(element -> (VariableElement) element)
             .toList();
 
@@ -240,6 +243,10 @@ public class ConfigurationEvaluatorProcessor extends AbstractProcessor {
 
             mClose.execute(writer, scopes);
         });
+    }
+
+    private boolean isConstant(Element element) {
+        return element.getModifiers().containsAll(Set.of(Modifier.STATIC, Modifier.FINAL));
     }
 
     private String getGetterMethod(final String field) {

--- a/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/result/TestConfiguration.java
+++ b/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/result/TestConfiguration.java
@@ -29,6 +29,8 @@ import java.util.Set;
 @ConfigurationEvaluator(attributePrefix = "gravitee.attributes.endpoint.test")
 public class TestConfiguration {
 
+    private static final String CONSTANT = "my_constant_should_be_ignored";
+
     //Enum
     private SecurityProtocol protocol = SecurityProtocol.PLAINTEXT;
 


### PR DESCRIPTION
…notation processor will ignore them)

**Description**

Add the ability to use constant in configuration bean by ignoring them in the ConfigurationEvaluator annotation processor.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.1.1-feat-manage-constant-in-annotation-processor-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/plugin/gravitee-plugin/2.1.1-feat-manage-constant-in-annotation-processor-SNAPSHOT/gravitee-plugin-2.1.1-feat-manage-constant-in-annotation-processor-SNAPSHOT.zip)
  <!-- Version placeholder end -->
