### PR TITLE
feat: add way to get plugin by id from plugin registry

### DIFF
--- a/gravitee-plugin-alert/pom.xml
+++ b/gravitee-plugin-alert/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.plugin</groupId>
         <artifactId>gravitee-plugin</artifactId>
-        <version>2.1.2</version>
+        <version>2.2.0-archi-143-add-get-plugin-by-id-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-plugin-alert</artifactId>

--- a/gravitee-plugin-annotation-processors/pom.xml
+++ b/gravitee-plugin-annotation-processors/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.gravitee.plugin</groupId>
         <artifactId>gravitee-plugin</artifactId>
-        <version>2.1.2</version>
+        <version>2.2.0-archi-143-add-get-plugin-by-id-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-plugin-annotation-processors</artifactId>

--- a/gravitee-plugin-api/pom.xml
+++ b/gravitee-plugin-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.plugin</groupId>
         <artifactId>gravitee-plugin</artifactId>
-        <version>2.1.2</version>
+        <version>2.2.0-archi-143-add-get-plugin-by-id-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-plugin-api</artifactId>

--- a/gravitee-plugin-cockpit/pom.xml
+++ b/gravitee-plugin-cockpit/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>gravitee-plugin</artifactId>
         <groupId>io.gravitee.plugin</groupId>
-        <version>2.1.2</version>
+        <version>2.2.0-archi-143-add-get-plugin-by-id-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-plugin-cockpit</artifactId>

--- a/gravitee-plugin-connector/pom.xml
+++ b/gravitee-plugin-connector/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.plugin</groupId>
         <artifactId>gravitee-plugin</artifactId>
-        <version>2.1.2</version>
+        <version>2.2.0-archi-143-add-get-plugin-by-id-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-plugin-connector</artifactId>

--- a/gravitee-plugin-core/pom.xml
+++ b/gravitee-plugin-core/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.plugin</groupId>
         <artifactId>gravitee-plugin</artifactId>
-        <version>2.1.2</version>
+        <version>2.2.0-archi-143-add-get-plugin-by-id-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-plugin-core</artifactId>

--- a/gravitee-plugin-core/src/main/java/io/gravitee/plugin/core/api/PluginRegistry.java
+++ b/gravitee-plugin-core/src/main/java/io/gravitee/plugin/core/api/PluginRegistry.java
@@ -26,4 +26,6 @@ public interface PluginRegistry extends Service<PluginRegistry> {
     Collection<Plugin> plugins();
 
     Collection<Plugin> plugins(String type);
+
+    Plugin get(String type, String id);
 }

--- a/gravitee-plugin-fetcher/pom.xml
+++ b/gravitee-plugin-fetcher/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.plugin</groupId>
         <artifactId>gravitee-plugin</artifactId>
-        <version>2.1.2</version>
+        <version>2.2.0-archi-143-add-get-plugin-by-id-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-plugin-fetcher</artifactId>

--- a/gravitee-plugin-identityprovider/pom.xml
+++ b/gravitee-plugin-identityprovider/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.plugin</groupId>
         <artifactId>gravitee-plugin</artifactId>
-        <version>2.1.2</version>
+        <version>2.2.0-archi-143-add-get-plugin-by-id-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-plugin-identityprovider</artifactId>

--- a/gravitee-plugin-notifier/pom.xml
+++ b/gravitee-plugin-notifier/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.plugin</groupId>
         <artifactId>gravitee-plugin</artifactId>
-        <version>2.1.2</version>
+        <version>2.2.0-archi-143-add-get-plugin-by-id-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-plugin-notifier</artifactId>

--- a/gravitee-plugin-policy/pom.xml
+++ b/gravitee-plugin-policy/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.plugin</groupId>
         <artifactId>gravitee-plugin</artifactId>
-        <version>2.1.2</version>
+        <version>2.2.0-archi-143-add-get-plugin-by-id-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-plugin-policy</artifactId>

--- a/gravitee-plugin-repository/pom.xml
+++ b/gravitee-plugin-repository/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.plugin</groupId>
         <artifactId>gravitee-plugin</artifactId>
-        <version>2.1.2</version>
+        <version>2.2.0-archi-143-add-get-plugin-by-id-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-plugin-repository</artifactId>

--- a/gravitee-plugin-resource/pom.xml
+++ b/gravitee-plugin-resource/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.plugin</groupId>
         <artifactId>gravitee-plugin</artifactId>
-        <version>2.1.2</version>
+        <version>2.2.0-archi-143-add-get-plugin-by-id-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-plugin-resource</artifactId>

--- a/gravitee-plugin-service-discovery/pom.xml
+++ b/gravitee-plugin-service-discovery/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.plugin</groupId>
         <artifactId>gravitee-plugin</artifactId>
-        <version>2.1.2</version>
+        <version>2.2.0-archi-143-add-get-plugin-by-id-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-plugin-service-discovery</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>io.gravitee.plugin</groupId>
     <artifactId>gravitee-plugin</artifactId>
-    <version>2.1.2</version>
+    <version>2.2.0-archi-143-add-get-plugin-by-id-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Gravitee.io APIM - Plugin</name>
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/ARCHI-143

**Description**

This PR adds a way to get a plugin by ID from the plugin registry.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.2.0-archi-143-add-get-plugin-by-id-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/plugin/gravitee-plugin/2.2.0-archi-143-add-get-plugin-by-id-SNAPSHOT/gravitee-plugin-2.2.0-archi-143-add-get-plugin-by-id-SNAPSHOT.zip)
  <!-- Version placeholder end -->
