### PR TITLE
fix: clone configuration instead of creating a new one

### DIFF
--- a/gravitee-plugin-annotation-processors/pom.xml
+++ b/gravitee-plugin-annotation-processors/pom.xml
@@ -61,6 +61,11 @@
             <artifactId>lombok</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
         <!-- Tests dependencies -->
         <dependency>
             <groupId>com.google.testing.compile</groupId>

--- a/gravitee-plugin-annotation-processors/src/main/resources/templates/evaluatorHeader.mustache
+++ b/gravitee-plugin-annotation-processors/src/main/resources/templates/evaluatorHeader.mustache
@@ -15,13 +15,14 @@
 */
 package {{packageName}};
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.gravitee.gateway.reactive.api.ExecutionFailure;
 import io.gravitee.gateway.reactive.api.context.ExecutionContext;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
-
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
@@ -42,6 +43,8 @@ public class {{evaluatorSimpleClassName}} {
     private static final String FAILURE_CONFIGURATION_INVALID = "FAILURE_CONFIGURATION_INVALID";
 
     private final Logger logger = LoggerFactory.getLogger({{evaluatorSimpleClassName}}.class);
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     private final {{simpleClassName}} configuration;
 
@@ -194,8 +197,14 @@ public class {{evaluatorSimpleClassName}} {
             return Single.just(evaluatedConf);
         }
 
-        {{simpleClassName}} evaluatedConfiguration = new {{simpleClassName}}();
+        {{simpleClassName}} evaluatedConfiguration;
+        try {
+            evaluatedConfiguration = objectMapper.readValue(objectMapper.writeValueAsString(configuration), {{simpleClassName}}.class);
+        } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+            logger.error("Unable to clone configuration", e);
+            return Single.error(e);
+        }
+
         String currentAttributePrefix = attributePrefix;
 
         List<Maybe<String>> toEval = new ArrayList<>();
-

--- a/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/result/KeyStore.java
+++ b/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/result/KeyStore.java
@@ -15,6 +15,13 @@
  */
 package io.gravitee.plugin.annotation.processor.result;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class KeyStore {
 
     private String key;

--- a/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/result/SecurityConfiguration.java
+++ b/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/result/SecurityConfiguration.java
@@ -15,6 +15,13 @@
  */
 package io.gravitee.plugin.annotation.processor.result;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class SecurityConfiguration {
 
     private String property;

--- a/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/result/Ssl.java
+++ b/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/result/Ssl.java
@@ -15,6 +15,13 @@
  */
 package io.gravitee.plugin.annotation.processor.result;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Ssl {
 
     private KeyStore keyStore;

--- a/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/result/TrustStore.java
+++ b/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/result/TrustStore.java
@@ -15,6 +15,13 @@
  */
 package io.gravitee.plugin.annotation.processor.result;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class TrustStore {
 
     private String key;

--- a/gravitee-plugin-annotation-processors/src/test/resources/test/TestConfigurationEvaluator.java
+++ b/gravitee-plugin-annotation-processors/src/test/resources/test/TestConfigurationEvaluator.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.plugin.annotation.processor.result;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.gateway.reactive.api.ExecutionFailure;
 import io.gravitee.gateway.reactive.api.context.ExecutionContext;
 import io.reactivex.rxjava3.core.Completable;
@@ -39,6 +40,8 @@ public class TestConfigurationEvaluator {
     private static final String FAILURE_CONFIGURATION_INVALID = "FAILURE_CONFIGURATION_INVALID";
 
     private final Logger logger = LoggerFactory.getLogger(TestConfigurationEvaluator.class);
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     private final TestConfiguration configuration;
 
@@ -179,7 +182,13 @@ public class TestConfigurationEvaluator {
             return Single.just(evaluatedConf);
         }
 
-        TestConfiguration evaluatedConfiguration = new TestConfiguration();
+        TestConfiguration evaluatedConfiguration;
+        try {
+            evaluatedConfiguration = objectMapper.readValue(objectMapper.writeValueAsString(configuration), TestConfiguration.class);
+        } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+            logger.error("Unable to clone configuration", e);
+            return Single.error(e);
+        }
         String currentAttributePrefix = attributePrefix;
 
         List<Maybe<String>> toEval = new ArrayList<>();


### PR DESCRIPTION
**Description**

Creating a new configuration based on the default constructor led to inconsistency when the class does not define default values.
To prevent that, we are cloning the configuration provided at the beginning of the evaluator.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.2.1-fix-annotation-processor-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/plugin/gravitee-plugin/2.2.1-fix-annotation-processor-SNAPSHOT/gravitee-plugin-2.2.1-fix-annotation-processor-SNAPSHOT.zip)
  <!-- Version placeholder end -->
