### PR TITLE
feat: use latest bom version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <name>Gravitee.io APIM - Plugin</name>
 
     <properties>
-        <gravitee-bom.version>7.0.0-archi-296-upgrade-bom-SNAPSHOT</gravitee-bom.version>
+        <gravitee-bom.version>7.0.0</gravitee-bom.version>
         <gravitee-common.version>3.3.3</gravitee-common.version>
         <gravitee-gateway-api.version>2.1.0</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <name>Gravitee.io APIM - Plugin</name>
 
     <properties>
-        <gravitee-bom.version>6.0.1</gravitee-bom.version>
+        <gravitee-bom.version>7.0.0-archi-296-upgrade-bom-SNAPSHOT</gravitee-bom.version>
         <gravitee-common.version>3.3.3</gravitee-common.version>
         <gravitee-gateway-api.version>2.1.0</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/ARCHI-296

**Description**

apply bom v7

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.1.0-archi-296-upgrade-bom-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/plugin/gravitee-plugin/3.1.0-archi-296-upgrade-bom-SNAPSHOT/gravitee-plugin-3.1.0-archi-296-upgrade-bom-SNAPSHOT.zip)
  <!-- Version placeholder end -->
