### PR TITLE
fix: simplify plugins comparison - 3.x

### DIFF
--- a/gravitee-plugin-core/src/main/java/io/gravitee/plugin/core/internal/AbstractPluginEventListener.java
+++ b/gravitee-plugin-core/src/main/java/io/gravitee/plugin/core/internal/AbstractPluginEventListener.java
@@ -81,8 +81,7 @@ public abstract class AbstractPluginEventListener
                 .sorted(
                     Comparator
                         .<Plugin>comparingInt(o -> o.manifest().priority())
-                        .thenComparing(new PluginComparator())
-                        .thenComparing(new SecretProviderPluginComparator())
+                        .thenComparing(new PluginComparator(environment.getProperty("secrets.loadFirst")))
                 )
                 .toList();
 
@@ -127,17 +126,31 @@ public abstract class AbstractPluginEventListener
 
     private record PluginKey(String id, String type) {}
 
-    private static class PluginComparator implements Comparator<Plugin> {
+    protected static class PluginComparator implements Comparator<Plugin> {
+
+        private final String loadFirst;
+
+        public PluginComparator(String loadFirst) {
+            this.loadFirst = loadFirst;
+        }
 
         @Override
         public int compare(Plugin o1, Plugin o2) {
-            Integer pos1 = pluginPriority.indexOf(o1.type());
-            Integer pos2 = pluginPriority.indexOf(o2.type());
+            if (loadFirst != null && o1.manifest().type().equalsIgnoreCase(SECRET_PROVIDER)) {
+                if (o1.manifest().id().equals(loadFirst)) {
+                    return -1;
+                } else if (o2.manifest().id().equals(loadFirst)) {
+                    return 1;
+                }
+            }
+
+            int pos1 = pluginPriority.indexOf(o1.type());
+            int pos2 = pluginPriority.indexOf(o2.type());
 
             if (pos1 >= 0) {
                 if (pos2 >= 0) {
                     // The plugin are both defined in the priority list. Respect the order defined.
-                    return pos1.compareTo(pos2);
+                    return Integer.compare(pos1, pos2);
                 }
 
                 // The second plugin is not defined in the priority list, plugin 1 takes precedence.
@@ -150,23 +163,6 @@ public abstract class AbstractPluginEventListener
             }
 
             // Both plugins are not in the priority list, keep the order unchanged.
-            return 0;
-        }
-    }
-
-    private class SecretProviderPluginComparator implements Comparator<Plugin> {
-
-        private final String loadedFirst;
-
-        public SecretProviderPluginComparator() {
-            this.loadedFirst = environment.getProperty("secrets.loadFirst");
-        }
-
-        @Override
-        public int compare(Plugin o1, Plugin o2) {
-            if (loadedFirst != null && Objects.equals(o1.manifest().type(), SECRET_PROVIDER) && o1.manifest().id().equals(loadedFirst)) {
-                return -1;
-            }
             return 0;
         }
     }

--- a/gravitee-plugin-core/src/test/java/io/gravitee/plugin/core/internal/PluginEventListenerTest.java
+++ b/gravitee-plugin-core/src/test/java/io/gravitee/plugin/core/internal/PluginEventListenerTest.java
@@ -16,6 +16,7 @@
 package io.gravitee.plugin.core.internal;
 
 import static io.gravitee.plugin.core.api.PluginEvent.DEPLOYED;
+import static io.gravitee.plugin.core.internal.PluginEventListener.SECRET_PROVIDER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
@@ -29,6 +30,7 @@ import java.util.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -110,7 +112,7 @@ class PluginEventListenerTest {
 
     @Test
     void should_load_secret_provider_first() {
-        final Plugin plugin_1 = createPlugin("plugin1", "secret-provider", null);
+        final Plugin plugin_1 = createPlugin("plugin1", SECRET_PROVIDER, null);
         final Plugin plugin_2 = createPlugin("plugin2", "cluster", null);
         final Plugin plugin_3 = createPlugin("plugin3", "foo", null);
 
@@ -131,9 +133,9 @@ class PluginEventListenerTest {
     @ParameterizedTest
     @CsvSource({ "plugin1,plugin2,plugin3", "plugin2,plugin1,plugin3", "plugin3,plugin2,plugin1" })
     void should_load_specific_secret_provider_first(String firstPlugin, String secondPlugin, String thirdPlugin) {
-        final Plugin plugin_1 = createPlugin(firstPlugin, "secret-provider", null);
-        final Plugin plugin_2 = createPlugin(secondPlugin, "secret-provider", null);
-        final Plugin plugin_3 = createPlugin(thirdPlugin, "secret-provider", null);
+        final Plugin plugin_1 = createPlugin(firstPlugin, SECRET_PROVIDER, null);
+        final Plugin plugin_2 = createPlugin(secondPlugin, SECRET_PROVIDER, null);
+        final Plugin plugin_3 = createPlugin(thirdPlugin, SECRET_PROVIDER, null);
         when(environment.getProperty("secrets.loadFirst")).thenReturn("plugin1");
 
         // publish in random order
@@ -162,5 +164,37 @@ class PluginEventListenerTest {
             manifestProperties.put(PluginManifestProperties.MANIFEST_DEPENDENCIES_PROPERTY, dependency);
         }
         return new PluginImpl(PluginManifestFactory.create(manifestProperties));
+    }
+
+    @Test
+    /*
+     In some not well identified cases, the plugins sort ends with this exception: 'java.lang.IllegalArgumentException: Comparison method violates its general contract!'
+     We managed to reproduce this exception with a list of plugins containing multiple times the same entities.
+     To avoid this, we had to fix the SecretProviderPluginComparator, so it returns also positive values
+     */
+    void should_compare_secret_provider_plugin() {
+        final Plugin plugin_01 = createPlugin("plugin_01", SECRET_PROVIDER, null);
+        final Plugin plugin_02 = createPlugin("plugin_02", SECRET_PROVIDER, null);
+        final Plugin plugin_03 = createPlugin("plugin_03", "cache", null);
+        final ArrayList<Plugin> plugins = new ArrayList<>();
+        for (int i = 0; i < 30; i++) {
+            plugins.add(plugin_01);
+            plugins.add(plugin_02);
+            plugins.add(plugin_03);
+        }
+
+        List<Plugin> sortedList = plugins
+            .stream()
+            .sorted(
+                Comparator
+                    .<Plugin>comparingInt(o -> o.manifest().priority())
+                    .thenComparing(new AbstractPluginEventListener.PluginComparator("plugin_01"))
+            )
+            .toList();
+
+        assertThat(sortedList).hasSize(90);
+        for (int i = 0; i < 30; i++) {
+            assertThat(sortedList.get(i).id()).isEqualTo("plugin_01");
+        }
     }
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-4080

**Description**

Merge the SecretProviderPluginComparator logic into the PluginComparator to respect `Comparator` contract.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.1.1-apim-4080-fix-plugin-comparator-3-x-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/plugin/gravitee-plugin/3.1.1-apim-4080-fix-plugin-comparator-3-x-SNAPSHOT/gravitee-plugin-3.1.1-apim-4080-fix-plugin-comparator-3-x-SNAPSHOT.zip)
  <!-- Version placeholder end -->
