### PR TITLE
feat: add new cloudserviceprovider plugin type

### DIFF
--- a/gravitee-plugin-cloudserviceprovider/pom.xml
+++ b/gravitee-plugin-cloudserviceprovider/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.gravitee.plugin</groupId>
+        <artifactId>gravitee-plugin</artifactId>
+        <version>4.1.0</version>
+    </parent>
+
+    <artifactId>gravitee-plugin-cloudserviceprovider</artifactId>
+    <name>Gravitee.io - Plugin - Cloud Service Provider</name>
+
+    <dependencies>
+        <!-- Gravitee dependencies -->
+        <dependency>
+            <groupId>io.gravitee.plugin</groupId>
+            <artifactId>gravitee-plugin-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.cloudservice</groupId>
+            <artifactId>gravitee-cloudservice-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.common</groupId>
+            <artifactId>gravitee-common</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/gravitee-plugin-cloudserviceprovider/src/main/java/io/gravitee/plugin/cloudserviceprovider/CloudServiceProviderClassLoaderFactory.java
+++ b/gravitee-plugin-cloudserviceprovider/src/main/java/io/gravitee/plugin/cloudserviceprovider/CloudServiceProviderClassLoaderFactory.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.cloudserviceprovider;
+
+import io.gravitee.plugin.core.api.PluginClassLoader;
+import io.gravitee.plugin.core.api.PluginClassLoaderFactory;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface CloudServiceProviderClassLoaderFactory extends PluginClassLoaderFactory<CloudServiceProviderPlugin> {
+    @Override
+    default PluginClassLoader getOrCreateClassLoader(CloudServiceProviderPlugin cloudServiceProviderPlugin) {
+        return getOrCreateClassLoader(cloudServiceProviderPlugin, cloudServiceProviderPlugin.getClass().getClassLoader());
+    }
+}

--- a/gravitee-plugin-cloudserviceprovider/src/main/java/io/gravitee/plugin/cloudserviceprovider/CloudServiceProviderPlugin.java
+++ b/gravitee-plugin-cloudserviceprovider/src/main/java/io/gravitee/plugin/cloudserviceprovider/CloudServiceProviderPlugin.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.cloudserviceprovider;
+
+import io.gravitee.cloudservice.api.plugin.configuration.CloudServiceProviderConfiguration;
+import io.gravitee.plugin.core.api.ConfigurablePlugin;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface CloudServiceProviderPlugin<C extends CloudServiceProviderConfiguration> extends ConfigurablePlugin<C> {
+    String PLUGIN_TYPE = "cloudservice-provider";
+
+    Class<?> cloudServiceProvider();
+
+    @Override
+    default String type() {
+        return PLUGIN_TYPE;
+    }
+}

--- a/gravitee-plugin-cloudserviceprovider/src/main/java/io/gravitee/plugin/cloudserviceprovider/CloudServiceProviderPluginManager.java
+++ b/gravitee-plugin-cloudserviceprovider/src/main/java/io/gravitee/plugin/cloudserviceprovider/CloudServiceProviderPluginManager.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.cloudserviceprovider;
+
+import io.gravitee.cloudservice.api.plugin.CloudServiceProviderFactory;
+import io.gravitee.plugin.core.api.ConfigurablePluginManager;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface CloudServiceProviderPluginManager extends ConfigurablePluginManager<CloudServiceProviderPlugin> {
+    CloudServiceProviderFactory<?> getCloudServiceProviderFactory(String pluginId);
+
+    CloudServiceProviderFactory<?> getCloudServiceProviderFactory(String pluginId, boolean includeNotDeployed);
+}

--- a/gravitee-plugin-cloudserviceprovider/src/main/java/io/gravitee/plugin/cloudserviceprovider/internal/CloudServiceProviderConfigurationClassFinder.java
+++ b/gravitee-plugin-cloudserviceprovider/src/main/java/io/gravitee/plugin/cloudserviceprovider/internal/CloudServiceProviderConfigurationClassFinder.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.cloudserviceprovider.internal;
+
+import io.gravitee.cloudservice.api.plugin.configuration.CloudServiceProviderConfiguration;
+import io.gravitee.plugin.core.api.AbstractSingleSubTypesFinder;
+import java.util.Collection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class CloudServiceProviderConfigurationClassFinder extends AbstractSingleSubTypesFinder<CloudServiceProviderConfiguration> {
+
+    private final Logger LOGGER = LoggerFactory.getLogger(CloudServiceProviderConfigurationClassFinder.class);
+
+    public CloudServiceProviderConfigurationClassFinder() {
+        super(CloudServiceProviderConfiguration.class);
+    }
+
+    @Override
+    public Collection<Class<? extends CloudServiceProviderConfiguration>> lookup(Class clazz, ClassLoader classLoader) {
+        LOGGER.debug(
+            "Looking for a configuration class for cloud service provider {} in package {}",
+            clazz.getName(),
+            clazz.getPackage().getName()
+        );
+        Collection<Class<? extends CloudServiceProviderConfiguration>> configurations = super.lookup(clazz, classLoader);
+
+        if (configurations.isEmpty()) {
+            LOGGER.info("No cloud service provider configuration class defined for cloud service provider {}", clazz.getName());
+        }
+
+        return configurations;
+    }
+}

--- a/gravitee-plugin-cloudserviceprovider/src/main/java/io/gravitee/plugin/cloudserviceprovider/internal/CloudServiceProviderPluginHandler.java
+++ b/gravitee-plugin-cloudserviceprovider/src/main/java/io/gravitee/plugin/cloudserviceprovider/internal/CloudServiceProviderPluginHandler.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.cloudserviceprovider.internal;
+
+import io.gravitee.plugin.cloudserviceprovider.CloudServiceProviderPlugin;
+import io.gravitee.plugin.cloudserviceprovider.spring.CloudServiceProviderPluginConfiguration;
+import io.gravitee.plugin.core.api.AbstractSimplePluginHandler;
+import io.gravitee.plugin.core.api.Plugin;
+import java.io.IOException;
+import java.net.URLClassLoader;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Import(CloudServiceProviderPluginConfiguration.class)
+public class CloudServiceProviderPluginHandler extends AbstractSimplePluginHandler<CloudServiceProviderPlugin> {
+
+    @Autowired
+    private DefaultCloudServiceProviderPluginManager cloudServiceProviderPluginManager;
+
+    @Override
+    public boolean canHandle(Plugin plugin) {
+        return CloudServiceProviderPlugin.PLUGIN_TYPE.equalsIgnoreCase(plugin.type());
+    }
+
+    @Override
+    protected String type() {
+        return "cloudservice-providers";
+    }
+
+    @Override
+    protected CloudServiceProviderPlugin create(Plugin plugin, Class<?> pluginClass) {
+        DefaultCloudServiceProviderPlugin cloudServiceProviderPlugin = new DefaultCloudServiceProviderPlugin(plugin, pluginClass);
+        cloudServiceProviderPlugin.setConfiguration(new CloudServiceProviderConfigurationClassFinder().lookupFirst(pluginClass));
+
+        return cloudServiceProviderPlugin;
+    }
+
+    @Override
+    protected void register(CloudServiceProviderPlugin cloudServiceProviderPlugin) {
+        cloudServiceProviderPluginManager.register(cloudServiceProviderPlugin);
+
+        // Once registered, the classloader should be released
+        URLClassLoader classLoader = (URLClassLoader) cloudServiceProviderPlugin.cloudServiceProvider().getClassLoader();
+        try {
+            classLoader.close();
+        } catch (IOException e) {
+            logger.error("Unexpected exception while trying to release the cloud service provider classloader");
+        }
+    }
+
+    @Override
+    protected ClassLoader getClassLoader(Plugin plugin) {
+        return new URLClassLoader(plugin.dependencies(), this.getClass().getClassLoader());
+    }
+}

--- a/gravitee-plugin-cloudserviceprovider/src/main/java/io/gravitee/plugin/cloudserviceprovider/internal/DefaultCloudServiceProviderClassLoaderFactory.java
+++ b/gravitee-plugin-cloudserviceprovider/src/main/java/io/gravitee/plugin/cloudserviceprovider/internal/DefaultCloudServiceProviderClassLoaderFactory.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.cloudserviceprovider.internal;
+
+import io.gravitee.plugin.cloudserviceprovider.CloudServiceProviderClassLoaderFactory;
+import io.gravitee.plugin.cloudserviceprovider.CloudServiceProviderPlugin;
+import io.gravitee.plugin.core.internal.PluginClassLoaderFactoryImpl;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class DefaultCloudServiceProviderClassLoaderFactory
+    extends PluginClassLoaderFactoryImpl<CloudServiceProviderPlugin>
+    implements CloudServiceProviderClassLoaderFactory {}

--- a/gravitee-plugin-cloudserviceprovider/src/main/java/io/gravitee/plugin/cloudserviceprovider/internal/DefaultCloudServiceProviderPlugin.java
+++ b/gravitee-plugin-cloudserviceprovider/src/main/java/io/gravitee/plugin/cloudserviceprovider/internal/DefaultCloudServiceProviderPlugin.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.plugin.cloudserviceprovider.internal;
+
+import io.gravitee.cloudservice.api.plugin.configuration.CloudServiceProviderConfiguration;
+import io.gravitee.plugin.cloudserviceprovider.CloudServiceProviderPlugin;
+import io.gravitee.plugin.core.api.Plugin;
+import io.gravitee.plugin.core.api.PluginManifest;
+import java.net.URL;
+import java.nio.file.Path;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class DefaultCloudServiceProviderPlugin implements CloudServiceProviderPlugin {
+
+    private final Plugin plugin;
+    private final Class<?> cloudServiceProviderClass;
+    private Class<? extends CloudServiceProviderConfiguration> cloudServiceProviderConfigurationClass;
+
+    DefaultCloudServiceProviderPlugin(final Plugin plugin, final Class<?> cloudServiceProviderClass) {
+        this.plugin = plugin;
+        this.cloudServiceProviderClass = cloudServiceProviderClass;
+        this.cloudServiceProviderConfigurationClass = null;
+    }
+
+    @Override
+    public Class<?> cloudServiceProvider() {
+        return cloudServiceProviderClass;
+    }
+
+    @Override
+    public String clazz() {
+        return plugin.clazz();
+    }
+
+    @Override
+    public URL[] dependencies() {
+        return plugin.dependencies();
+    }
+
+    @Override
+    public String id() {
+        return plugin.id();
+    }
+
+    @Override
+    public PluginManifest manifest() {
+        return plugin.manifest();
+    }
+
+    @Override
+    public Path path() {
+        return plugin.path();
+    }
+
+    @Override
+    public boolean deployed() {
+        return plugin.deployed();
+    }
+
+    @Override
+    public Class<? extends CloudServiceProviderConfiguration> configuration() {
+        return cloudServiceProviderConfigurationClass;
+    }
+
+    public void setConfiguration(Class<? extends CloudServiceProviderConfiguration> cloudServiceProviderConfigurationClass) {
+        this.cloudServiceProviderConfigurationClass = cloudServiceProviderConfigurationClass;
+    }
+}

--- a/gravitee-plugin-cloudserviceprovider/src/main/java/io/gravitee/plugin/cloudserviceprovider/internal/DefaultCloudServiceProviderPluginManager.java
+++ b/gravitee-plugin-cloudserviceprovider/src/main/java/io/gravitee/plugin/cloudserviceprovider/internal/DefaultCloudServiceProviderPluginManager.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.cloudserviceprovider.internal;
+
+import io.gravitee.cloudservice.api.plugin.CloudServiceProviderFactory;
+import io.gravitee.plugin.cloudserviceprovider.CloudServiceProviderClassLoaderFactory;
+import io.gravitee.plugin.cloudserviceprovider.CloudServiceProviderPlugin;
+import io.gravitee.plugin.cloudserviceprovider.CloudServiceProviderPluginManager;
+import io.gravitee.plugin.core.api.AbstractConfigurablePluginManager;
+import io.gravitee.plugin.core.api.PluginClassLoader;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@RequiredArgsConstructor
+@Slf4j
+public class DefaultCloudServiceProviderPluginManager
+    extends AbstractConfigurablePluginManager<CloudServiceProviderPlugin>
+    implements CloudServiceProviderPluginManager {
+
+    private final CloudServiceProviderClassLoaderFactory classLoaderFactory;
+
+    private final Map<String, CloudServiceProviderFactory<?>> factories = new HashMap<>();
+    private final Map<String, CloudServiceProviderFactory<?>> undeployedFactories = new HashMap<>();
+
+    @Override
+    public void register(CloudServiceProviderPlugin plugin) {
+        super.register(plugin);
+
+        // Create cloudServiceProvider
+        PluginClassLoader pluginClassLoader = classLoaderFactory.getOrCreateClassLoader(plugin);
+        try {
+            final Class<CloudServiceProviderFactory<?>> cloudServiceProviderFactoryClass =
+                (Class<CloudServiceProviderFactory<?>>) pluginClassLoader.loadClass(plugin.clazz());
+            final CloudServiceProviderFactory<?> factory = cloudServiceProviderFactoryClass.getDeclaredConstructor().newInstance();
+            if (plugin.deployed()) {
+                factories.put(plugin.id(), factory);
+            } else {
+                undeployedFactories.put(plugin.id(), factory);
+            }
+        } catch (Exception ex) {
+            log.error("Unexpected error while loading cloud service provider plugin: {}", plugin.clazz(), ex);
+        }
+    }
+
+    @Override
+    public CloudServiceProviderFactory<?> getCloudServiceProviderFactory(String pluginId) {
+        return factories.get(pluginId);
+    }
+
+    @Override
+    public CloudServiceProviderFactory<?> getCloudServiceProviderFactory(String pluginId, boolean includeNotDeployed) {
+        CloudServiceProviderFactory<?> factory = factories.get(pluginId);
+        if (factory == null && includeNotDeployed) {
+            return undeployedFactories.get(pluginId);
+        }
+        return factory;
+    }
+}

--- a/gravitee-plugin-cloudserviceprovider/src/main/java/io/gravitee/plugin/cloudserviceprovider/spring/CloudServiceProviderPluginConfiguration.java
+++ b/gravitee-plugin-cloudserviceprovider/src/main/java/io/gravitee/plugin/cloudserviceprovider/spring/CloudServiceProviderPluginConfiguration.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.cloudserviceprovider.spring;
+
+import io.gravitee.plugin.cloudserviceprovider.CloudServiceProviderClassLoaderFactory;
+import io.gravitee.plugin.cloudserviceprovider.internal.CloudServiceProviderPluginHandler;
+import io.gravitee.plugin.cloudserviceprovider.internal.DefaultCloudServiceProviderClassLoaderFactory;
+import io.gravitee.plugin.cloudserviceprovider.internal.DefaultCloudServiceProviderPluginManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Configuration
+public class CloudServiceProviderPluginConfiguration {
+
+    @Bean
+    public DefaultCloudServiceProviderPluginManager cloudServiceProviderPluginManager(
+        final CloudServiceProviderClassLoaderFactory cloudServiceProviderClassLoaderFactory
+    ) {
+        return new DefaultCloudServiceProviderPluginManager(cloudServiceProviderClassLoaderFactory);
+    }
+
+    @Bean
+    public CloudServiceProviderClassLoaderFactory cloudServiceProviderClassLoaderFactory() {
+        return new DefaultCloudServiceProviderClassLoaderFactory();
+    }
+
+    @Bean
+    CloudServiceProviderPluginHandler cloudServiceProviderPluginHandler() {
+        return new CloudServiceProviderPluginHandler();
+    }
+}

--- a/gravitee-plugin-cloudserviceprovider/src/main/resources/META-INF/spring.factories
+++ b/gravitee-plugin-cloudserviceprovider/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+io.gravitee.plugin.core.api.PluginHandler=\
+    io.gravitee.plugin.cloudserviceprovider.internal.CloudServiceProviderPluginHandler

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
         <gravitee-cockpit-api.version>3.0.8</gravitee-cockpit-api.version>
         <gravitee-connector-api.version>1.1.4</gravitee-connector-api.version>
         <gravitee-integration-api.version>1.0.0</gravitee-integration-api.version>
+        <gravitee-cloudservice-api.version>1.0.0-SNAPSHOT</gravitee-cloudservice-api.version>
     </properties>
 
     <modules>
@@ -66,6 +67,7 @@
         <module>gravitee-plugin-connector</module>
         <module>gravitee-plugin-annotation-processors</module>
         <module>gravitee-plugin-integrationprovider</module>
+        <module>gravitee-plugin-cloudserviceprovider</module>
     </modules>
 
     <dependencyManagement>
@@ -142,6 +144,11 @@
             <dependency>
                 <groupId>io.gravitee.plugin</groupId>
                 <artifactId>gravitee-plugin-annotation-processors</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.gravitee.plugin</groupId>
+                <artifactId>gravitee-plugin-cloudserviceprovider</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
@@ -222,6 +229,12 @@
                 <groupId>io.gravitee.integration</groupId>
                 <artifactId>gravitee-integration-api</artifactId>
                 <version>${gravitee-integration-api.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.gravitee.cloudservice</groupId>
+                <artifactId>gravitee-cloudservice-api</artifactId>
+                <version>${gravitee-cloudservice-api.version}</version>
             </dependency>
 
             <!-- Reflection utils -->


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/ARCHI-384

**Description**

This PR is a part of a POC regarding Cloud Services. The concept is described in this slab page https://gravitee.slab.com/posts/cloud-services-analysis-l8279ptc
The goal is to have a new type of plugin for Gravitee Cloud that will manage the business logic specific to each service provider (i.e. a scoring provider).