### PR TITLE
ARCHI-397 feat: introduced 'repository.' prefix for its properties.

### DIFF
--- a/gravitee-plugin-core/src/test/java/io/gravitee/plugin/core/internal/PluginRegistryTest.java
+++ b/gravitee-plugin-core/src/test/java/io/gravitee/plugin/core/internal/PluginRegistryTest.java
@@ -164,6 +164,8 @@ class PluginRegistryTest {
 
     @Test
     void start_with_valid_workspace_with_one_dependency_with_alias_disabled() throws Exception {
+        when(environment.containsProperty("policies.my-policy-2.enabled")).thenReturn(true);
+        when(environment.containsProperty("policies.my-policy-3.enabled")).thenReturn(true);
         when(environment.containsProperty("policies.my-policy-1.enabled")).thenReturn(true);
         when(environment.getProperty("policies.my-policy-1.enabled", Boolean.class, true)).thenReturn(false);
 

--- a/gravitee-plugin-repository/src/main/java/io/gravitee/plugin/repository/internal/RepositoryPluginHandler.java
+++ b/gravitee-plugin-repository/src/main/java/io/gravitee/plugin/repository/internal/RepositoryPluginHandler.java
@@ -65,6 +65,8 @@ public class RepositoryPluginHandler extends AbstractPluginHandler {
 
     private final Map<Scope, RepositoryProvider> repositories = new HashMap<>();
 
+    private final RepositoryTypeReader repositoryTypeReader = new RepositoryTypeReader();
+
     private void initialize() {
         if (initialized.compareAndSet(false, true)) {
             RepositoryScopeProvider scopeProvider = applicationContext.getBean(RepositoryScopeProvider.class);
@@ -211,7 +213,7 @@ public class RepositoryPluginHandler extends AbstractPluginHandler {
     }
 
     private String getRepositoryType(Scope scope) {
-        return environment.getProperty(scope.getName() + ".type");
+        return repositoryTypeReader.getRepositoryType(environment, scope);
     }
 
     private <T> T createInstance(Class<T> clazz) throws Exception {

--- a/gravitee-plugin-repository/src/main/java/io/gravitee/plugin/repository/internal/RepositoryTypeReader.java
+++ b/gravitee-plugin-repository/src/main/java/io/gravitee/plugin/repository/internal/RepositoryTypeReader.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.repository.internal;
+
+import io.gravitee.platform.repository.api.Scope;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.env.Environment;
+
+@RequiredArgsConstructor
+@Slf4j
+class RepositoryTypeReader {
+
+    String getRepositoryType(Environment environment, Scope scope) {
+        String oldKey = scope.getName() + ".type";
+        String newKey = "repositories." + oldKey;
+        String repositoryType = environment.getProperty(newKey);
+        if (repositoryType != null) {
+            return repositoryType;
+        } else {
+            repositoryType = environment.getProperty(oldKey);
+            if (repositoryType != null) {
+                log.warn("The repository of scope {} is loaded from discouraged section '{}'. Please use '{}'.", scope, oldKey, newKey);
+            }
+            return repositoryType;
+        }
+    }
+}

--- a/gravitee-plugin-repository/src/test/java/io/gravitee/plugin/repository/internal/RepositoryTypeReaderTest.java
+++ b/gravitee-plugin-repository/src/test/java/io/gravitee/plugin/repository/internal/RepositoryTypeReaderTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.repository.internal;
+
+import io.gravitee.platform.repository.api.Scope;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.core.env.Environment;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RepositoryTypeReaderTest {
+
+    @Mock
+    Environment environment;
+
+    RepositoryTypeReader reader = new RepositoryTypeReader();
+
+    @Test
+    public void scope_should_been_read_from_repositories_section_first() {
+        Mockito.when(environment.getProperty("repositories.management.type")).thenReturn("mongodb");
+
+        String type = reader.getRepositoryType(environment, Scope.MANAGEMENT);
+        Assert.assertEquals("mongodb", type);
+    }
+
+    @Test
+    public void scope_should_been_read_from_old_structure_as_fallback() {
+        Mockito.when(environment.getProperty("repositories.management.type")).thenReturn(null);
+        Mockito.when(environment.getProperty("management.type")).thenReturn("jdbc");
+
+        String type = reader.getRepositoryType(environment, Scope.MANAGEMENT);
+        Assert.assertEquals("jdbc", type);
+    }
+
+    @Test
+    public void should_return_null_when_properties_are_missing() {
+        Mockito.when(environment.getProperty("repositories.management.type")).thenReturn(null);
+        Mockito.when(environment.getProperty("management.type")).thenReturn(null);
+
+        String type = reader.getRepositoryType(environment, Scope.MANAGEMENT);
+        Assert.assertNull(type);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <gravitee-alert-api.version>1.9.1</gravitee-alert-api.version>
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>
         <gravitee-service-discovery-api.version>1.1.1</gravitee-service-discovery-api.version>
-        <gravitee-platform-repository-api.version>1.3.0</gravitee-platform-repository-api.version>
+        <gravitee-platform-repository-api.version>1.4.0</gravitee-platform-repository-api.version>
         <reflections.version>0.9.11</reflections.version>
         <gravitee-identityprovider-api.version>1.0.0</gravitee-identityprovider-api.version>
         <gravitee-cockpit-api.version>3.0.8</gravitee-cockpit-api.version>


### PR DESCRIPTION
solves ARCHI-397
moved to new properties structure. Old approach remained as a fallback option. 
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.2.0-feature-ARCHI-397-new-repostiory-properties-structure-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/plugin/gravitee-plugin/4.2.0-feature-ARCHI-397-new-repostiory-properties-structure-SNAPSHOT/gravitee-plugin-4.2.0-feature-ARCHI-397-new-repostiory-properties-structure-SNAPSHOT.zip)
  <!-- Version placeholder end -->
