### PR TITLE
fix: declare all modules in dependency management

### DIFF
--- a/gravitee-plugin-alert/pom.xml
+++ b/gravitee-plugin-alert/pom.xml
@@ -39,7 +39,6 @@
         <dependency>
             <groupId>io.gravitee.plugin</groupId>
             <artifactId>gravitee-plugin-core</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>io.gravitee.common</groupId>

--- a/gravitee-plugin-connector/pom.xml
+++ b/gravitee-plugin-connector/pom.xml
@@ -35,7 +35,6 @@
         <dependency>
             <groupId>io.gravitee.plugin</groupId>
             <artifactId>gravitee-plugin-core</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/gravitee-plugin-fetcher/pom.xml
+++ b/gravitee-plugin-fetcher/pom.xml
@@ -40,7 +40,6 @@
         <dependency>
             <groupId>io.gravitee.plugin</groupId>
             <artifactId>gravitee-plugin-core</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/gravitee-plugin-notifier/pom.xml
+++ b/gravitee-plugin-notifier/pom.xml
@@ -35,7 +35,6 @@
         <dependency>
             <groupId>io.gravitee.plugin</groupId>
             <artifactId>gravitee-plugin-core</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/gravitee-plugin-policy/pom.xml
+++ b/gravitee-plugin-policy/pom.xml
@@ -35,7 +35,6 @@
         <dependency>
             <groupId>io.gravitee.plugin</groupId>
             <artifactId>gravitee-plugin-core</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/gravitee-plugin-resource/pom.xml
+++ b/gravitee-plugin-resource/pom.xml
@@ -35,7 +35,6 @@
         <dependency>
             <groupId>io.gravitee.plugin</groupId>
             <artifactId>gravitee-plugin-core</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/gravitee-plugin-service-discovery/pom.xml
+++ b/gravitee-plugin-service-discovery/pom.xml
@@ -35,7 +35,6 @@
         <dependency>
             <groupId>io.gravitee.plugin</groupId>
             <artifactId>gravitee-plugin-core</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -81,37 +81,17 @@
             <!-- Self import modules -->
             <dependency>
                 <groupId>io.gravitee.plugin</groupId>
-                <artifactId>gravitee-plugin-api</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.gravitee.plugin</groupId>
-                <artifactId>gravitee-plugin-core</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.gravitee.plugin</groupId>
-                <artifactId>gravitee-plugin-policy</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.gravitee.plugin</groupId>
-                <artifactId>gravitee-plugin-connector</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.gravitee.plugin</groupId>
-                <artifactId>gravitee-plugin-resource</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.gravitee.plugin</groupId>
-                <artifactId>gravitee-plugin-fetcher</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.gravitee.plugin</groupId>
                 <artifactId>gravitee-plugin-alert</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.gravitee.plugin</groupId>
+                <artifactId>gravitee-plugin-annotation-processors</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.gravitee.plugin</groupId>
+                <artifactId>gravitee-plugin-api</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
@@ -121,17 +101,17 @@
             </dependency>
             <dependency>
                 <groupId>io.gravitee.plugin</groupId>
-                <artifactId>gravitee-plugin-service-discovery</artifactId>
+                <artifactId>gravitee-plugin-connector</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.gravitee.plugin</groupId>
-                <artifactId>gravitee-plugin-notifier</artifactId>
+                <artifactId>gravitee-plugin-core</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.gravitee.plugin</groupId>
-                <artifactId>gravitee-plugin-repository</artifactId>
+                <artifactId>gravitee-plugin-fetcher</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
@@ -141,7 +121,32 @@
             </dependency>
             <dependency>
                 <groupId>io.gravitee.plugin</groupId>
-                <artifactId>gravitee-plugin-annotation-processors</artifactId>
+                <artifactId>gravitee-plugin-integrationprovider</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.gravitee.plugin</groupId>
+                <artifactId>gravitee-plugin-notifier</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.gravitee.plugin</groupId>
+                <artifactId>gravitee-plugin-policy</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.gravitee.plugin</groupId>
+                <artifactId>gravitee-plugin-repository</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.gravitee.plugin</groupId>
+                <artifactId>gravitee-plugin-resource</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.gravitee.plugin</groupId>
+                <artifactId>gravitee-plugin-service-discovery</artifactId>
                 <version>${project.version}</version>
             </dependency>
 


### PR DESCRIPTION
**Issue**

N/A

**Description**

To allow importing gravitee-plugin in the dependency management section of another project's pom.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.2.1-fix-dependency-management-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/plugin/gravitee-plugin/4.2.1-fix-dependency-management-SNAPSHOT/gravitee-plugin-4.2.1-fix-dependency-management-SNAPSHOT.zip)
  <!-- Version placeholder end -->
