### PR TITLE
fix: fix resource access for null plugins

### DIFF
--- a/gravitee-plugin-core/src/main/java/io/gravitee/plugin/core/api/AbstractConfigurablePluginManager.java
+++ b/gravitee-plugin-core/src/main/java/io/gravitee/plugin/core/api/AbstractConfigurablePluginManager.java
@@ -49,6 +49,9 @@ public abstract class AbstractConfigurablePluginManager<T extends ConfigurablePl
     @Override
     public String getSchema(String pluginId, boolean includeNotDeployed) throws IOException {
         final T plugin = get(pluginId, includeNotDeployed);
+        if (plugin == null) {
+            return null;
+        }
         String schemaProperty = plugin.manifest().properties().get(PluginManifestProperties.SCHEMA_PROPERTY);
 
         if (schemaProperty != null) {
@@ -71,6 +74,9 @@ public abstract class AbstractConfigurablePluginManager<T extends ConfigurablePl
     @Override
     public String getSchema(String pluginId, String propertyKey, boolean fallbackToSchema, boolean includeNotDeployed) throws IOException {
         final T plugin = get(pluginId, includeNotDeployed);
+        if (plugin == null) {
+            return null;
+        }
 
         String schemaProperty = plugin.manifest().properties().get(propertyKey);
         if (schemaProperty != null) {
@@ -106,6 +112,9 @@ public abstract class AbstractConfigurablePluginManager<T extends ConfigurablePl
     @Override
     public String getDocumentation(String pluginId, boolean includeNotDeployed) throws IOException {
         final T plugin = get(pluginId, includeNotDeployed);
+        if (plugin == null) {
+            return null;
+        }
 
         var documentationProperty = plugin.manifest().properties().get(PluginManifestProperties.DOCUMENTATION_PROPERTY);
         if (documentationProperty != null) {
@@ -119,6 +128,9 @@ public abstract class AbstractConfigurablePluginManager<T extends ConfigurablePl
     public String getDocumentation(String pluginId, String propertyKey, boolean fallbackToDocumentation, boolean includeNotDeployed)
         throws IOException {
         final T plugin = get(pluginId, includeNotDeployed);
+        if (plugin == null) {
+            return null;
+        }
 
         String documentationProperty = plugin.manifest().properties().get(propertyKey);
         if (documentationProperty != null) {

--- a/gravitee-plugin-core/src/test/java/io/gravitee/plugin/core/api/AbstractConfigurablePluginManagerTest.java
+++ b/gravitee-plugin-core/src/test/java/io/gravitee/plugin/core/api/AbstractConfigurablePluginManagerTest.java
@@ -70,6 +70,12 @@ class AbstractConfigurablePluginManagerTest {
     }
 
     @Test
+    void should_get_schema_null_for_non_existing_plugin() throws IOException {
+        final String schema = cut.getSchema(FAKE_PLUGIN);
+        assertNull(schema);
+    }
+
+    @Test
     void should_get_schema_file_with_default_property() throws IOException {
         properties.put("schema", "subfolder_A/schema-form-v1.json");
 
@@ -124,6 +130,12 @@ class AbstractConfigurablePluginManagerTest {
         cut.register(new FakePlugin());
         final String schema = cut.getDocumentation(FAKE_PLUGIN);
         assertEquals("plugin BIS documentation", schema);
+    }
+
+    @Test
+    void should_get_documentation_null_for_non_existing_plugin() throws IOException {
+        final String schema = cut.getDocumentation(FAKE_PLUGIN);
+        assertNull(schema);
     }
 
     @Test


### PR DESCRIPTION
Shared policy group are not a regular plugin and have neither documentation nor schema, so null check must be properly done

