### PR TITLE
feat: add EL support for io.gravitee.common.http.HttpHeader List

### DIFF
--- a/gravitee-plugin-annotation-processors/README.adoc
+++ b/gravitee-plugin-annotation-processors/README.adoc
@@ -44,7 +44,8 @@ So if we want for example override the `bootstrapServers` attribute of the Kafka
 
 You need to assign an attribute named `gravitee.attributes.endpoint.kafka.bootstrapServers`
 
-The annotation processor supports these types: String, Integer, Boolean, Enum, Set and List.
+#The annotation processor supports these types: String, Integer, Boolean, Enum, Set and List.
+EL support is offered for: String, List<String> and List<HttpHeader> (from gravitee-common).#
 
 ==== Evaluate EL on string type properties
 

--- a/gravitee-plugin-annotation-processors/src/main/resources/templates/evalField.mustache
+++ b/gravitee-plugin-annotation-processors/src/main/resources/templates/evalField.mustache
@@ -8,10 +8,16 @@
                 toEvalList.add(
                     eval{{fieldType}}Property("{{fieldName}}", {{originalConfigurationName}}.{{fieldGetter}}(), currentAttributePrefix, baseExecutionContext)
                 {{/toEvalList}}
+                {{#toEvalHeaderList}}
+                    toEvalHeaderList.add(
+                    eval{{fieldType}}Property("{{fieldName}}", {{originalConfigurationName}}.{{fieldGetter}}(), currentAttributePrefix, baseExecutionContext)
+                {{/toEvalHeaderList}}
                 {{^toEval}}
                     {{^toEvalList}}
+                        {{^toEvalHeaderList}}
                     {{evaluatedConfigurationName}}.{{fieldSetter}}(
                     eval{{fieldType}}Property("{{fieldName}}", {{originalConfigurationName}}.{{fieldGetter}}(), {{#fieldClass}}{{fieldClass}}.class, {{/fieldClass}}currentAttributePrefix, baseExecutionContext)
+                        {{/toEvalHeaderList}}
                     {{/toEvalList}}
                 {{/toEval}}
                 {{#toEval}}
@@ -20,6 +26,9 @@
                 {{#toEvalList}}
                     .doOnSuccess(value -> {{evaluatedConfigurationName}}.{{fieldSetter}}(value))
                 {{/toEvalList}}
+                {{#toEvalHeaderList}}
+                    .doOnSuccess(value -> {{evaluatedConfigurationName}}.{{fieldSetter}}(value))
+                {{/toEvalHeaderList}}
                 );
             } else if(deploymentContext != null) {
                 {{#toEval}}
@@ -32,4 +41,9 @@
                     eval{{fieldType}}Property("{{fieldName}}", {{originalConfigurationName}}.{{fieldGetter}}(), currentAttributePrefix, deploymentContext)
                     .doOnSuccess(value -> {{evaluatedConfigurationName}}.{{fieldSetter}}(value)));
                 {{/toEvalList}}
+                {{#toEvalHeaderList}}
+                    toEvalHeaderList.add(
+                    eval{{fieldType}}Property("{{fieldName}}", {{originalConfigurationName}}.{{fieldGetter}}(), currentAttributePrefix, deploymentContext)
+                    .doOnSuccess(value -> {{evaluatedConfigurationName}}.{{fieldSetter}}(value)));
+                {{/toEvalHeaderList}}
             }

--- a/gravitee-plugin-annotation-processors/src/main/resources/templates/evaluatorFooter.mustache
+++ b/gravitee-plugin-annotation-processors/src/main/resources/templates/evaluatorFooter.mustache
@@ -1,8 +1,10 @@
 
         // Evaluate properties that needs EL, validate evaluatedConf and returns it
-        return Maybe
-            .concat(Flowable.fromIterable(toEval))
-            .ignoreElements()
+        Completable toEvalCompletable = Flowable.fromIterable(toEval).concatMapMaybe(m -> m).ignoreElements();
+        Completable toEvalListCompletable = Flowable.fromIterable(toEvalList).concatMapMaybe(m -> m).ignoreElements();
+        Completable toEvalHeaderListCompletable = Flowable.fromIterable(toEvalHeaderList).concatMapMaybe(m -> m).ignoreElements();
+
+        return Completable.concatArray(toEvalCompletable, toEvalListCompletable, toEvalHeaderListCompletable)
             .andThen(Completable.fromRunnable(() -> validateConfiguration(evaluatedConfiguration)))
             .andThen(Completable.fromRunnable(() -> {
                 if(baseExecutionContext != null) {

--- a/gravitee-plugin-annotation-processors/src/main/resources/templates/evaluatorHeader.mustache
+++ b/gravitee-plugin-annotation-processors/src/main/resources/templates/evaluatorHeader.mustache
@@ -16,6 +16,7 @@
 package {{packageName}};
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.common.http.HttpHeader;
 import io.gravitee.gateway.reactive.api.ExecutionFailure;
 import io.gravitee.gateway.reactive.api.context.DeploymentContext;
 import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
@@ -130,7 +131,7 @@ public class {{evaluatorSimpleClassName}} {
             .doOnSubscribe(d -> ctx.getTemplateEngine().getTemplateContext().setVariable(SecretFieldAccessControl.EL_VARIABLE, accessControl))
             .doOnTerminate(() -> ctx.getTemplateEngine().getTemplateContext().setVariable(SecretFieldAccessControl.EL_VARIABLE, null))
             .doOnError(throwable -> logger.error("Unable to evaluate property [{}] with expression [{}].", property, value));
-        }
+    }
 
     private <T extends Enum<T>> T evalEnumProperty(String name, T value, Class<T> enumClass, String attributePrefix, BaseExecutionContext ctx) {
         String attribute = ctx.getAttribute(buildAttributeName(attributePrefix, name));
@@ -227,6 +228,81 @@ public class {{evaluatorSimpleClassName}} {
             .toMaybe();
     }
 
+    private Maybe<List<HttpHeader>> evalListHeaderProperty(
+        String name,
+        List<HttpHeader> headers,
+        String attributePrefix,
+        BaseExecutionContext ctx
+    ) {
+        //First check attributes
+        String attributeName = buildAttributeName(attributePrefix, name);
+        List<HttpHeader> attribute = ctx.getAttribute(attributeName);
+        if (attribute != null) {
+            //If a value is found for this attribute, override the original value with it
+            headers = attribute;
+        }
+        //If headers is null, return empty
+        if (headers == null) {
+            return Maybe.empty();
+        }
+
+        //Then check EL
+        return Flowable
+            .fromIterable(headers)
+            .filter(Objects::nonNull)
+            .flatMapMaybe(header -> {
+                SecretFieldAccessControl accessControl = new SecretFieldAccessControl(true, FieldKind.HEADER, header.getName());
+                return ctx
+                    .getTemplateEngine()
+                    .eval(header.getValue(), String.class)
+                    .doOnSubscribe(d ->
+                        ctx.getTemplateEngine().getTemplateContext().setVariable(SecretFieldAccessControl.EL_VARIABLE, accessControl)
+                    )
+                    .doOnTerminate(() ->
+                        ctx.getTemplateEngine().getTemplateContext().setVariable(SecretFieldAccessControl.EL_VARIABLE, null)
+                    )
+                    .map(evaluatedValue -> new HttpHeader(header.getName(), evaluatedValue))
+                    .doOnError(throwable -> logger.error("Unable to evaluate property [{}] with expression [{}].", name, header.getValue())
+                );
+            })
+            .toList()
+            .toMaybe();
+        }
+
+    private Maybe<List<HttpHeader>> evalListHeaderProperty(
+        String name,
+        List<HttpHeader> headers,
+        String attributePrefix,
+        DeploymentContext ctx
+    ) {
+        //If headers is null, return empty
+        if (headers == null) {
+            return Maybe.empty();
+        }
+
+        //Then check EL
+        return Flowable
+            .fromIterable(headers)
+            .filter(Objects::nonNull)
+            .flatMapMaybe(header -> {
+                SecretFieldAccessControl accessControl = new SecretFieldAccessControl(true, FieldKind.HEADER, header.getName());
+                return ctx
+                    .getTemplateEngine()
+                    .eval(header.getValue(), String.class)
+                    .doOnSubscribe(d ->
+                        ctx.getTemplateEngine().getTemplateContext().setVariable(SecretFieldAccessControl.EL_VARIABLE, accessControl)
+                    )
+                    .doOnTerminate(() ->
+                        ctx.getTemplateEngine().getTemplateContext().setVariable(SecretFieldAccessControl.EL_VARIABLE, null)
+                    )
+                    .map(evaluatedValue -> new HttpHeader(header.getName(), evaluatedValue))
+                    .doOnError(throwable -> logger.error("Unable to evaluate property [{}] with expression [{}].", name, header.getValue())
+                    );
+            })
+            .toList()
+            .toMaybe();
+    }
+
     private <T> void validateConfiguration(T configuration) {
         Set<ConstraintViolation<T>> constraintViolations = validator.validate(configuration);
 
@@ -314,3 +390,4 @@ public class {{evaluatorSimpleClassName}} {
 
         List<Maybe<String>> toEval = new ArrayList<>();
         List<Maybe<List<String>>> toEvalList = new ArrayList<>();
+        List<Maybe<List<HttpHeader>>> toEvalHeaderList = new ArrayList<>();

--- a/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/result/TestConfiguration.java
+++ b/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/result/TestConfiguration.java
@@ -19,11 +19,13 @@
  */
 package io.gravitee.plugin.annotation.processor.result;
 
+import io.gravitee.common.http.HttpHeader;
 import io.gravitee.plugin.annotation.ConfigurationEvaluator;
 import io.gravitee.plugin.annotation.processor.result.ssl.SslOptions;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -48,11 +50,26 @@ public class TestConfiguration {
     @Valid
     private Consumer consumer = new Consumer();
 
-    public TestConfiguration(SecurityProtocol protocol, Ssl ssl, SecurityConfiguration security, Consumer consumer) {
+    //Inner class with name different from class name
+    @Valid
+    private Authentication auth;
+
+    private List<HttpHeader> headers = new ArrayList<>();
+
+    public TestConfiguration(
+        SecurityProtocol protocol,
+        Ssl ssl,
+        SecurityConfiguration security,
+        Consumer consumer,
+        Authentication auth,
+        List<HttpHeader> headers
+    ) {
         this.protocol = protocol;
         this.ssl = ssl;
         this.security = security;
         this.consumer = consumer;
+        this.auth = auth;
+        this.headers = headers;
     }
 
     public TestConfiguration() {}
@@ -71,6 +88,22 @@ public class TestConfiguration {
 
     public void setSsl(Ssl ssl) {
         this.ssl = ssl;
+    }
+
+    public Authentication getAuth() {
+        return auth;
+    }
+
+    public void setAuth(Authentication auth) {
+        this.auth = auth;
+    }
+
+    public List<HttpHeader> getHeaders() {
+        return headers;
+    }
+
+    public void setHeaders(List<HttpHeader> headers) {
+        this.headers = headers;
     }
 
     public SslOptions getSslOptions() {
@@ -107,6 +140,14 @@ public class TestConfiguration {
 
     private static Ssl $default$ssl() {
         return new Ssl();
+    }
+
+    private static Authentication $default$auth() {
+        return new Authentication();
+    }
+
+    private static List<HttpHeader> $default$headers() {
+        return new ArrayList<>();
     }
 
     public static TestConfigurationBuilder builder() {
@@ -257,6 +298,95 @@ public class TestConfiguration {
         }
     }
 
+    public static class Authentication {
+
+        private String username;
+        private String password;
+
+        public Authentication(String username, String password) {
+            this.username = username;
+            this.password = password;
+        }
+
+        public Authentication() {}
+
+        public static AuthenticationBuilder builder() {
+            return new AuthenticationBuilder();
+        }
+
+        public String getUsername() {
+            return this.username;
+        }
+
+        public String getPassword() {
+            return this.password;
+        }
+
+        public void setUsername(String username) {
+            this.username = username;
+        }
+
+        public void setPassword(String password) {
+            this.password = password;
+        }
+
+        public boolean equals(final Object o) {
+            if (o == this) return true;
+            if (!(o instanceof Authentication)) return false;
+            final Authentication other = (Authentication) o;
+            if (!other.canEqual((Object) this)) return false;
+            final Object this$username = this.getUsername();
+            final Object other$username = other.getUsername();
+            if (this$username == null ? other$username != null : !this$username.equals(other$username)) return false;
+            final Object this$password = this.getPassword();
+            final Object other$password = other.getPassword();
+            if (this$password == null ? other$password != null : !this$password.equals(other$password)) return false;
+            return true;
+        }
+
+        protected boolean canEqual(final Object other) {
+            return other instanceof Authentication;
+        }
+
+        public int hashCode() {
+            final int PRIME = 59;
+            int result = 1;
+            final Object $username = this.getUsername();
+            result = result * PRIME + ($username == null ? 43 : $username.hashCode());
+            final Object $password = this.getPassword();
+            result = result * PRIME + ($password == null ? 43 : $password.hashCode());
+            return result;
+        }
+
+        public static class AuthenticationBuilder {
+
+            private String username;
+            private String password;
+
+            AuthenticationBuilder() {}
+
+            public AuthenticationBuilder username(String username) {
+                this.username = username;
+                return this;
+            }
+
+            public AuthenticationBuilder password(String password) {
+                this.password = password;
+                return this;
+            }
+
+            public Authentication build() {
+                return new Authentication(this.username, this.password);
+            }
+
+            public String toString() {
+                return (
+                    "TestConfiguration.Authentication.AuthenticationBuilder(username=" + this.username + ", password=" + this.password + ")"
+                );
+            }
+        }
+    }
+
     public static class TestConfigurationBuilder {
 
         private Consumer consumer$value;
@@ -267,6 +397,12 @@ public class TestConfiguration {
         private SecurityProtocol protocol = SecurityProtocol.PLAINTEXT;
         private Ssl ssl$value;
         private boolean ssl$set;
+
+        private Authentication auth$value;
+        private boolean auth$set;
+
+        private List<HttpHeader> headers$value;
+        private boolean headers$set;
 
         TestConfigurationBuilder() {}
 
@@ -293,6 +429,18 @@ public class TestConfiguration {
             return this;
         }
 
+        public TestConfigurationBuilder auth(Authentication auth) {
+            this.auth$value = auth;
+            this.auth$set = true;
+            return this;
+        }
+
+        public TestConfigurationBuilder headers(List<HttpHeader> headers) {
+            this.headers$value = headers;
+            this.headers$set = true;
+            return this;
+        }
+
         public TestConfiguration build() {
             TestConfiguration.Consumer consumer$value = this.consumer$value;
             if (!this.consumer$set) {
@@ -307,7 +455,17 @@ public class TestConfiguration {
             if (!this.ssl$set) {
                 ssl$value = TestConfiguration.$default$ssl();
             }
-            return new TestConfiguration(protocol, ssl$value, security$value, consumer$value);
+
+            Authentication auth$value = this.auth$value;
+            if (!this.auth$set) {
+                auth$value = TestConfiguration.$default$auth();
+            }
+
+            List<HttpHeader> headers$value = this.headers$value;
+            if (!this.headers$set) {
+                headers$value = TestConfiguration.$default$headers();
+            }
+            return new TestConfiguration(protocol, ssl$value, security$value, consumer$value, auth$value, headers$value);
         }
 
         public String toString() {


### PR DESCRIPTION
in ConfigurationEvaluatorProcessor (and fix getter generation to use attribute name)

**Issue**

https://gravitee.atlassian.net/browse/APIM-7500

**Description**

Add EL support for HttpHeader List (gravitee-common) in annotation processor to complete the story on secret for Http Endpoint. Also fix an issue with getter generated based on class name instead of attribute name.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.5.0-feat-add-support-httpheader-list-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/plugin/gravitee-plugin/4.5.0-feat-add-support-httpheader-list-SNAPSHOT/gravitee-plugin-4.5.0-feat-add-support-httpheader-list-SNAPSHOT.zip)
  <!-- Version placeholder end -->
