### PR TITLE
feat: declare new plugin type 'data-plane' in the priority list

### DIFF
--- a/gravitee-plugin-core/src/main/java/io/gravitee/plugin/core/internal/AbstractPluginEventListener.java
+++ b/gravitee-plugin-core/src/main/java/io/gravitee/plugin/core/internal/AbstractPluginEventListener.java
@@ -21,7 +21,14 @@ import io.gravitee.common.service.AbstractService;
 import io.gravitee.plugin.core.api.Plugin;
 import io.gravitee.plugin.core.api.PluginEvent;
 import io.gravitee.plugin.core.api.PluginHandler;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -40,10 +47,19 @@ public abstract class AbstractPluginEventListener
     implements EventListener<PluginEvent, Plugin> {
 
     public static final String SECRET_PROVIDER = "secret-provider";
+    public static final String DATA_PLANE = "data-plane";
     /**
      * Allows to define priority between the different plugin types.
      */
-    private static final List<String> pluginPriority = Arrays.asList(SECRET_PROVIDER, "cluster", "cache", "repository", "alert", "cockpit");
+    private static final List<String> pluginPriority = Arrays.asList(
+        SECRET_PROVIDER,
+        "cluster",
+        "cache",
+        "repository",
+        DATA_PLANE,
+        "alert",
+        "cockpit"
+    );
 
     private final Collection<PluginHandler> pluginHandlers;
 


### PR DESCRIPTION
 this new plugin is only useful for AM but it need to be loaded after the reporitory plugin but before any other plugin

fixes AM-4564
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.6.0-am-4564-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/plugin/gravitee-plugin/4.6.0-am-4564-SNAPSHOT/gravitee-plugin-4.6.0-am-4564-SNAPSHOT.zip)
  <!-- Version placeholder end -->
