### PR TITLE
fix: annotation processor object mapper needs to ignore unknown prope…

### DIFF
--- a/gravitee-plugin-annotation-processors/src/main/resources/templates/evaluatorHeader.mustache
+++ b/gravitee-plugin-annotation-processors/src/main/resources/templates/evaluatorHeader.mustache
@@ -15,6 +15,7 @@
 */
 package {{packageName}};
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.common.http.HttpHeader;
 import io.gravitee.gateway.reactive.api.ExecutionFailure;
@@ -380,6 +381,7 @@ public class {{evaluatorSimpleClassName}} {
 
         {{simpleClassName}} evaluatedConfiguration;
         try {
+            objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
             evaluatedConfiguration = objectMapper.readValue(objectMapper.writeValueAsString(configuration), {{simpleClassName}}.class);
         } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
             logger.error("Unable to clone configuration", e);

--- a/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/result/TestConfiguration.java
+++ b/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/result/TestConfiguration.java
@@ -74,6 +74,10 @@ public class TestConfiguration {
 
     public TestConfiguration() {}
 
+    public boolean isSslEnabled() {
+        return (ssl != null && ((ssl.getKeyStore() != null && ssl.getKeyStore().getKey() != null)));
+    }
+
     public SecurityProtocol getProtocol() {
         return protocol;
     }

--- a/gravitee-plugin-annotation-processors/src/test/resources/test/TestConfigurationEvaluator.java
+++ b/gravitee-plugin-annotation-processors/src/test/resources/test/TestConfigurationEvaluator.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.plugin.annotation.processor.result;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.common.http.HttpHeader;
 import io.gravitee.gateway.reactive.api.ExecutionFailure;
@@ -380,6 +381,7 @@ public class TestConfigurationEvaluator {
 
         TestConfiguration evaluatedConfiguration;
         try {
+            objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
             evaluatedConfiguration = objectMapper.readValue(objectMapper.writeValueAsString(configuration), TestConfiguration.class);
         } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
             logger.error("Unable to clone configuration", e);


### PR DESCRIPTION
…rties to

avoid error when configuration contains other method like helper.

**Issue**

https://gravitee.atlassian.net/browse/APIM-7505

**Description**

This PR aims to fix an issue if the annotation processor tries to clone the current configuration but this configuration contains other methods like helper. This leads to an UnrecognizedPropertyException since the method could be serialized but unknown while deserializing. To avoid this, the object mapper is now configured to ignore the unknown properties.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.5.1-fix-mapper-annotation-processor-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/plugin/gravitee-plugin/4.5.1-fix-mapper-annotation-processor-SNAPSHOT/gravitee-plugin-4.5.1-fix-mapper-annotation-processor-SNAPSHOT.zip)
  <!-- Version placeholder end -->
