### PR TITLE
fix: avoid using primitive type for eval method

### DIFF
--- a/gravitee-plugin-annotation-processors/src/main/resources/templates/evaluatorHeader.mustache
+++ b/gravitee-plugin-annotation-processors/src/main/resources/templates/evaluatorHeader.mustache
@@ -142,7 +142,7 @@ public class {{evaluatorSimpleClassName}} {
         return value;
     }
 
-    private Integer evalIntegerProperty(String name, int value, String attributePrefix, BaseExecutionContext ctx) {
+    private Integer evalIntegerProperty(String name, Integer value, String attributePrefix, BaseExecutionContext ctx) {
         Integer attribute = ctx.getAttribute(buildAttributeName(attributePrefix, name));
         if (attribute != null) {
             return attribute;
@@ -150,7 +150,7 @@ public class {{evaluatorSimpleClassName}} {
         return value;
     }
 
-    private Long evalLongProperty(String name, long value, String attributePrefix, BaseExecutionContext ctx) {
+    private Long evalLongProperty(String name, Long value, String attributePrefix, BaseExecutionContext ctx) {
         Long attribute = ctx.getAttribute(buildAttributeName(attributePrefix, name));
         if (attribute != null) {
             return attribute;
@@ -158,10 +158,10 @@ public class {{evaluatorSimpleClassName}} {
         return value;
     }
 
-    private boolean evalBooleanProperty(String name, boolean value, String attributePrefix, BaseExecutionContext ctx) {
-        Object attribute = ctx.getAttribute(buildAttributeName(attributePrefix, name));
+    private Boolean evalBooleanProperty(String name, Boolean value, String attributePrefix, BaseExecutionContext ctx) {
+        Boolean attribute = ctx.getAttribute(buildAttributeName(attributePrefix, name));
         if (attribute != null) {
-            return (boolean) attribute;
+            return attribute;
         }
         return value;
     }

--- a/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/ConfigurationEvaluatorGeneratedTest.java
+++ b/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/ConfigurationEvaluatorGeneratedTest.java
@@ -108,6 +108,7 @@ public class ConfigurationEvaluatorGeneratedTest {
             .assertValue(testConfiguration -> {
                 assertThat(testConfiguration.getConsumer().getAutoOffsetReset()).isEqualTo("latest");
                 assertThat(testConfiguration.getConsumer().getTopics()).isEqualTo(Set.of("topic1", "topic2"));
+                assertThat(testConfiguration.getConsumer().getWindowSize()).isNull();
                 assertThat(testConfiguration.getConsumer().getAttributes()).isNotEmpty();
                 assertThat(testConfiguration.getConsumer().getAttributes()).containsExactly("attribute1", "my_dictionary_attribute");
                 assertThat(testConfiguration.getHeaders()).isNotEmpty();

--- a/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/result/TestConfiguration.java
+++ b/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/result/TestConfiguration.java
@@ -171,6 +171,8 @@ public class TestConfiguration {
         //Added to validate proper behavior when a String attribute is null
         private String topicPattern;
 
+        private Integer windowSize;
+
         private TrustStore trustStore;
 
         private List<String> attributes;
@@ -214,6 +216,14 @@ public class TestConfiguration {
 
         public void setTopicPattern(String topicPattern) {
             this.topicPattern = topicPattern;
+        }
+
+        public Integer getWindowSize() {
+            return windowSize;
+        }
+
+        public void setWindowSize(final Integer windowSize) {
+            this.windowSize = windowSize;
         }
 
         public TrustStore getTrustStore() {

--- a/gravitee-plugin-annotation-processors/src/test/resources/test/TestConfigurationEvaluator.java
+++ b/gravitee-plugin-annotation-processors/src/test/resources/test/TestConfigurationEvaluator.java
@@ -142,7 +142,7 @@ public class TestConfigurationEvaluator {
         return value;
     }
 
-    private Integer evalIntegerProperty(String name, int value, String attributePrefix, BaseExecutionContext ctx) {
+    private Integer evalIntegerProperty(String name, Integer value, String attributePrefix, BaseExecutionContext ctx) {
         Integer attribute = ctx.getAttribute(buildAttributeName(attributePrefix, name));
         if (attribute != null) {
             return attribute;
@@ -150,7 +150,7 @@ public class TestConfigurationEvaluator {
         return value;
     }
 
-    private Long evalLongProperty(String name, long value, String attributePrefix, BaseExecutionContext ctx) {
+    private Long evalLongProperty(String name, Long value, String attributePrefix, BaseExecutionContext ctx) {
         Long attribute = ctx.getAttribute(buildAttributeName(attributePrefix, name));
         if (attribute != null) {
             return attribute;
@@ -158,10 +158,10 @@ public class TestConfigurationEvaluator {
         return value;
     }
 
-    private boolean evalBooleanProperty(String name, boolean value, String attributePrefix, BaseExecutionContext ctx) {
-        Object attribute = ctx.getAttribute(buildAttributeName(attributePrefix, name));
+    private Boolean evalBooleanProperty(String name, Boolean value, String attributePrefix, BaseExecutionContext ctx) {
+        Boolean attribute = ctx.getAttribute(buildAttributeName(attributePrefix, name));
         if (attribute != null) {
-            return (boolean) attribute;
+            return attribute;
         }
         return value;
     }
@@ -450,6 +450,13 @@ public class TestConfigurationEvaluator {
                 toEval.add(
                         evalStringProperty("topicPattern", configuration.getConsumer().getTopicPattern(), currentAttributePrefix, deploymentContext, "")
                                 .doOnSuccess(value -> evaluatedConfiguration.getConsumer().setTopicPattern(value)));
+            }
+            //Field windowSize
+            if(baseExecutionContext != null) {
+                evaluatedConfiguration.getConsumer().setWindowSize(
+                        evalIntegerProperty("windowSize", configuration.getConsumer().getWindowSize(), currentAttributePrefix, baseExecutionContext)
+                );
+            } else if(deploymentContext != null) {
             }
             //Field attributes
             if(baseExecutionContext != null) {


### PR DESCRIPTION
**Description**

Fixing NPE on primitive type

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.6.1-fix-npe-on-primitive-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/plugin/gravitee-plugin/4.6.1-fix-npe-on-primitive-SNAPSHOT/gravitee-plugin-4.6.1-fix-npe-on-primitive-SNAPSHOT.zip)
  <!-- Version placeholder end -->
