### PR TITLE
Fix for error on disable analytics

### DIFF
--- a/gravitee-plugin-repository/src/main/java/io/gravitee/plugin/repository/internal/RepositoryPluginHandler.java
+++ b/gravitee-plugin-repository/src/main/java/io/gravitee/plugin/repository/internal/RepositoryPluginHandler.java
@@ -49,6 +49,9 @@ public class RepositoryPluginHandler extends AbstractPluginHandler {
 
     private static final String PLUGIN_TYPE = "repository";
 
+    public static final String ANALYTICS_ELASTIC = "elasticsearch";
+    public static final String ANALYTICS_NONE = "none";
+
     @Autowired
     private Environment environment;
 
@@ -178,6 +181,7 @@ public class RepositoryPluginHandler extends AbstractPluginHandler {
             if (
                 (
                     beanName.endsWith("Repository") ||
+                    beanName.endsWith("RepositoryV4") ||
                     beanName.endsWith("TransactionManager") &&
                     !repository.getClass().equals(repositoryClassInstance.getClass())
                 )
@@ -211,7 +215,17 @@ public class RepositoryPluginHandler extends AbstractPluginHandler {
     }
 
     private String getRepositoryType(Scope scope) {
-        return environment.getProperty(scope.getName() + ".type");
+        String repositoryType = environment.getProperty(scope.getName() + ".type");
+        if (scope.equals(Scope.ANALYTICS)) {
+            if (repositoryType != null) {
+                if (!repositoryType.equals(ANALYTICS_NONE) && !repositoryType.equals(ANALYTICS_ELASTIC)) {
+                    return ANALYTICS_ELASTIC;
+                } else return repositoryType;
+            }
+            return ANALYTICS_ELASTIC;
+        } else {
+            return repositoryType;
+        }
     }
 
     private <T> T createInstance(Class<T> clazz) throws Exception {


### PR DESCRIPTION

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.1.2-APIM-8643-Error-for-V4-API-logs-when-analytics-is-disabled-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/plugin/gravitee-plugin/3.1.2-APIM-8643-Error-for-V4-API-logs-when-analytics-is-disabled-SNAPSHOT/gravitee-plugin-3.1.2-APIM-8643-Error-for-V4-API-logs-when-analytics-is-disabled-SNAPSHOT.zip)
  <!-- Version placeholder end -->
