### PR TITLE
feat: allow to set Double in plugin config

### DIFF
--- a/gravitee-plugin-annotation-processors/src/main/resources/templates/evaluatorHeader.mustache
+++ b/gravitee-plugin-annotation-processors/src/main/resources/templates/evaluatorHeader.mustache
@@ -160,6 +160,14 @@ public class {{evaluatorSimpleClassName}} {
         return value;
     }
 
+    private Double evalDoubleProperty(String name, Double value, String attributePrefix, BaseExecutionContext ctx) {
+        Double attribute = ctx.getAttribute(buildAttributeName(attributePrefix, name));
+        if (attribute != null) {
+            return attribute;
+        }
+        return value;
+    }
+
     private Boolean evalBooleanProperty(String name, Boolean value, String attributePrefix, BaseExecutionContext ctx) {
         Boolean attribute = ctx.getAttribute(buildAttributeName(attributePrefix, name));
         if (attribute != null) {

--- a/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/result/TestConfiguration.java
+++ b/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/result/TestConfiguration.java
@@ -61,6 +61,8 @@ public class TestConfiguration {
 
     private List<HttpHeader> headers = new ArrayList<>();
 
+    private Double doubleValue;
+
     public TestConfiguration(
         SecurityProtocol protocol,
         Ssl ssl,
@@ -147,6 +149,14 @@ public class TestConfiguration {
 
     public void setSecurity(SecurityConfiguration security) {
         this.security = security;
+    }
+
+    public Double getDoubleValue() {
+        return doubleValue;
+    }
+
+    public void setDoubleValue(Double doubleValue) {
+        this.doubleValue = doubleValue;
     }
 
     private static TestConfiguration.Consumer $default$consumer() {

--- a/gravitee-plugin-annotation-processors/src/test/resources/test/TestConfigurationEvaluator.java
+++ b/gravitee-plugin-annotation-processors/src/test/resources/test/TestConfigurationEvaluator.java
@@ -160,6 +160,14 @@ public class TestConfigurationEvaluator {
         return value;
     }
 
+    private Double evalDoubleProperty(String name, Double value, String attributePrefix, BaseExecutionContext ctx) {
+        Double attribute = ctx.getAttribute(buildAttributeName(attributePrefix, name));
+        if (attribute != null) {
+            return attribute;
+        }
+        return value;
+    }
+
     private Boolean evalBooleanProperty(String name, Boolean value, String attributePrefix, BaseExecutionContext ctx) {
         Boolean attribute = ctx.getAttribute(buildAttributeName(attributePrefix, name));
         if (attribute != null) {
@@ -471,6 +479,13 @@ public class TestConfigurationEvaluator {
                     evalListHeaderProperty("headers", configuration.getHeaders(), currentAttributePrefix, deploymentContext)
                             .doOnSuccess(value -> evaluatedConfiguration.setHeaders(value)));
         }
+        //Field doubleValue
+        if(baseExecutionContext != null) {
+            evaluatedConfiguration.setDoubleValue(
+                    evalDoubleProperty("doubleValue", configuration.getDoubleValue(), currentAttributePrefix, baseExecutionContext)
+            );
+         } else if(deploymentContext != null) {
+         }
 
         //Consumer section begin
         if(evaluatedConfiguration.getConsumer() != null) {


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/XXXXX

**Description**

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.9.0-mba-double-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/plugin/gravitee-plugin/4.9.0-mba-double-SNAPSHOT/gravitee-plugin-4.9.0-mba-double-SNAPSHOT.zip)
  <!-- Version placeholder end -->
