### PR TITLE
feat(repository): add PropertySource to resolve repositories.* config prefix

### DIFF
--- a/gravitee-plugin-repository/src/main/java/io/gravitee/plugin/repository/internal/RepositoryAliasPropertySource.java
+++ b/gravitee-plugin-repository/src/main/java/io/gravitee/plugin/repository/internal/RepositoryAliasPropertySource.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.repository.internal;
+
+import io.gravitee.platform.repository.api.Scope;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.PropertySource;
+
+/**
+ * A {@link PropertySource} that transparently resolves legacy repository configuration keys
+ * to the new hierarchical format.
+ *
+ * <p>When application code reads a property like {@code management.mongodb.uri}, this source
+ * first checks for {@code repositories.management.mongodb.uri}. If found, that value is returned.
+ * If not, {@code null} is returned and the normal property resolution chain handles the legacy key.
+ */
+class RepositoryAliasPropertySource extends PropertySource<Object> {
+
+    static final String PROPERTY_SOURCE_NAME = "repositoryAliasPropertySource";
+    private static final String REPOSITORIES_PREFIX = "repositories.";
+
+    private static final Set<String> SCOPE_PREFIXES = Arrays
+        .stream(Scope.values())
+        .map(scope -> scope.getName() + ".")
+        .collect(Collectors.toSet());
+
+    private final Environment environment;
+
+    RepositoryAliasPropertySource(Environment environment) {
+        super(PROPERTY_SOURCE_NAME, new Object());
+        this.environment = environment;
+    }
+
+    @Override
+    public Object getProperty(@Nonnull String name) {
+        for (String scopePrefix : SCOPE_PREFIXES) {
+            if (name.startsWith(scopePrefix)) {
+                return environment.getProperty(REPOSITORIES_PREFIX + name);
+            }
+        }
+        return null;
+    }
+}

--- a/gravitee-plugin-repository/src/main/java/io/gravitee/plugin/repository/internal/RepositoryPluginHandler.java
+++ b/gravitee-plugin-repository/src/main/java/io/gravitee/plugin/repository/internal/RepositoryPluginHandler.java
@@ -34,6 +34,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.Environment;
 import org.springframework.util.Assert;
 
@@ -69,6 +70,8 @@ public class RepositoryPluginHandler extends AbstractPluginHandler {
 
     private void initialize() {
         if (initialized.compareAndSet(false, true)) {
+            registerAliasPropertySource();
+
             RepositoryScopeProvider scopeProvider = applicationContext.getBean(RepositoryScopeProvider.class);
 
             // Get all the scope handled by the plugin and check there is an associated configuration.
@@ -78,6 +81,20 @@ public class RepositoryPluginHandler extends AbstractPluginHandler {
 
             for (Scope scope : scopeProvider.getOptionalHandledScopes()) {
                 checkRepositoryConfig(scope, false);
+            }
+        }
+    }
+
+    /**
+     * Registers a {@link RepositoryAliasPropertySource} so that legacy config keys
+     * (e.g. {@code management.mongodb.uri}) are transparently resolved from the new
+     * hierarchical format ({@code repositories.management.mongodb.uri}) when present.
+     */
+    private void registerAliasPropertySource() {
+        if (environment instanceof ConfigurableEnvironment configurableEnv) {
+            if (configurableEnv.getPropertySources().get(RepositoryAliasPropertySource.PROPERTY_SOURCE_NAME) == null) {
+                configurableEnv.getPropertySources().addFirst(new RepositoryAliasPropertySource(environment));
+                LOGGER.debug("Registered RepositoryAliasPropertySource for repository configuration resolution");
             }
         }
     }

--- a/gravitee-plugin-repository/src/test/java/io/gravitee/plugin/repository/internal/RepositoryAliasPropertySourceTest.java
+++ b/gravitee-plugin-repository/src/test/java/io/gravitee/plugin/repository/internal/RepositoryAliasPropertySourceTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.repository.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.StandardEnvironment;
+
+public class RepositoryAliasPropertySourceTest {
+
+    private ConfigurableEnvironment environment;
+
+    @Before
+    public void setUp() {
+        environment = new StandardEnvironment();
+    }
+
+    private void setProperties(Map<String, Object> props) {
+        environment.getPropertySources().addFirst(new MapPropertySource("test", props));
+        environment.getPropertySources().addFirst(new RepositoryAliasPropertySource(environment));
+    }
+
+    @Test
+    public void should_resolve_management_mongodb_uri_from_new_prefix() {
+        setProperties(Map.of("repositories.management.mongodb.uri", "mongodb://newhost:27017/gravitee"));
+
+        assertEquals("mongodb://newhost:27017/gravitee", environment.getProperty("management.mongodb.uri"));
+    }
+
+    @Test
+    public void should_resolve_analytics_elasticsearch_endpoint_from_new_prefix() {
+        setProperties(Map.of("repositories.analytics.elasticsearch.endpoints[0]", "http://es-host:9200"));
+
+        assertEquals("http://es-host:9200", environment.getProperty("analytics.elasticsearch.endpoints[0]"));
+    }
+
+    @Test
+    public void should_resolve_ratelimit_redis_host_from_new_prefix() {
+        setProperties(Map.of("repositories.ratelimit.redis.host", "redis-host"));
+
+        assertEquals("redis-host", environment.getProperty("ratelimit.redis.host"));
+    }
+
+    @Test
+    public void should_fallback_to_old_prefix_when_new_prefix_not_set() {
+        setProperties(Map.of("management.mongodb.uri", "mongodb://oldhost:27017/gravitee"));
+
+        assertEquals("mongodb://oldhost:27017/gravitee", environment.getProperty("management.mongodb.uri"));
+    }
+
+    @Test
+    public void should_prefer_new_prefix_when_both_are_set() {
+        setProperties(
+            Map.of(
+                "management.mongodb.uri",
+                "mongodb://oldhost:27017/gravitee",
+                "repositories.management.mongodb.uri",
+                "mongodb://newhost:27017/gravitee"
+            )
+        );
+
+        assertEquals("mongodb://newhost:27017/gravitee", environment.getProperty("management.mongodb.uri"));
+    }
+
+    @Test
+    public void should_not_intercept_unrelated_properties() {
+        setProperties(Map.of("server.port", "8080"));
+
+        assertEquals("8080", environment.getProperty("server.port"));
+    }
+
+    @Test
+    public void should_return_null_for_missing_property() {
+        setProperties(Map.of());
+
+        assertNull(environment.getProperty("management.mongodb.uri"));
+    }
+
+    @Test
+    public void should_resolve_analytics_elasticsearch_security_username() {
+        setProperties(Map.of("repositories.analytics.elasticsearch.security.username", "elastic_user"));
+
+        assertEquals("elastic_user", environment.getProperty("analytics.elasticsearch.security.username"));
+    }
+
+    @Test
+    public void should_resolve_management_jdbc_url_from_new_prefix() {
+        setProperties(Map.of("repositories.management.jdbc.url", "jdbc:postgresql://pg-host/gravitee"));
+
+        assertEquals("jdbc:postgresql://pg-host/gravitee", environment.getProperty("management.jdbc.url"));
+    }
+
+    @Test
+    public void should_resolve_ratelimit_mongodb_uri_from_new_prefix() {
+        setProperties(Map.of("repositories.ratelimit.mongodb.uri", "mongodb://rl-host:27017/gravitee"));
+
+        assertEquals("mongodb://rl-host:27017/gravitee", environment.getProperty("ratelimit.mongodb.uri"));
+    }
+
+    @Test
+    public void should_resolve_elasticsearch_index_from_new_prefix() {
+        setProperties(Map.of("repositories.analytics.elasticsearch.index", "my-index"));
+
+        assertEquals("my-index", environment.getProperty("analytics.elasticsearch.index"));
+    }
+
+    @Test
+    public void should_resolve_multiple_elasticsearch_endpoints_from_new_prefix() {
+        setProperties(
+            Map.of(
+                "repositories.analytics.elasticsearch.endpoints[0]",
+                "http://es1:9200",
+                "repositories.analytics.elasticsearch.endpoints[1]",
+                "http://es2:9200"
+            )
+        );
+
+        assertEquals("http://es1:9200", environment.getProperty("analytics.elasticsearch.endpoints[0]"));
+        assertEquals("http://es2:9200", environment.getProperty("analytics.elasticsearch.endpoints[1]"));
+    }
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-11302

**Description**

Add a `PropertySource` that resolves legacy scope-prefixed config keys (e.g. `management.mongodb.uri`) to the new `repositories.*` hierarchical format.
It is registered with highest precedence so `repositories.*` keys take priority over legacy ones
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.11.0-fix-apim-11302-4-x-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/plugin/gravitee-plugin/4.11.0-fix-apim-11302-4-x-SNAPSHOT/gravitee-plugin-4.11.0-fix-apim-11302-4-x-SNAPSHOT.zip)
  <!-- Version placeholder end -->
