### PR TITLE
fix(repository): resolve legacy short keys first to let env vars override YAML

### DIFF
--- a/gravitee-plugin-repository/src/main/java/io/gravitee/plugin/repository/internal/RepositoryAliasPropertySource.java
+++ b/gravitee-plugin-repository/src/main/java/io/gravitee/plugin/repository/internal/RepositoryAliasPropertySource.java
@@ -59,12 +59,12 @@ class RepositoryAliasPropertySource extends PropertySource<Object> {
     }
 
     /**
-     * Resolves the property by checking the short key first (explicit override)
-     * across all sources, then falling back to the long key.
+     * Resolves the property by checking the legacy key first (explicit override)
+     * across all sources, then falling back to the new key.
      */
     private Object resolveRespectingSourcePriority(String name) {
         if (environment instanceof ConfigurableEnvironment configEnv) {
-            // Check if any source defines the short key directly (e.g. env var)
+            // Check if any source defines the legacy key directly (e.g. env var)
             for (PropertySource<?> ps : configEnv.getPropertySources()) {
                 if (ps == this) {
                     continue;
@@ -75,7 +75,7 @@ class RepositoryAliasPropertySource extends PropertySource<Object> {
                 }
             }
         }
-        // Fallback to long key
+        // Fallback to new key
         return environment.getProperty(REPOSITORIES_PREFIX + name);
     }
 }

--- a/gravitee-plugin-repository/src/main/java/io/gravitee/plugin/repository/internal/RepositoryAliasPropertySource.java
+++ b/gravitee-plugin-repository/src/main/java/io/gravitee/plugin/repository/internal/RepositoryAliasPropertySource.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.jspecify.annotations.NonNull;
+import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.PropertySource;
 
@@ -51,9 +52,30 @@ class RepositoryAliasPropertySource extends PropertySource<Object> {
     public Object getProperty(@NonNull String name) {
         for (String scopePrefix : SCOPE_PREFIXES) {
             if (name.startsWith(scopePrefix)) {
-                return environment.getProperty(REPOSITORIES_PREFIX + name);
+                return resolveRespectingSourcePriority(name);
             }
         }
         return null;
+    }
+
+    /**
+     * Resolves the property by checking the short key first (explicit override)
+     * across all sources, then falling back to the long key.
+     */
+    private Object resolveRespectingSourcePriority(String name) {
+        if (environment instanceof ConfigurableEnvironment configEnv) {
+            // Check if any source defines the short key directly (e.g. env var)
+            for (PropertySource<?> ps : configEnv.getPropertySources()) {
+                if (ps == this) {
+                    continue;
+                }
+                Object value = ps.getProperty(name);
+                if (value != null) {
+                    return value;
+                }
+            }
+        }
+        // Fallback to long key
+        return environment.getProperty(REPOSITORIES_PREFIX + name);
     }
 }

--- a/gravitee-plugin-repository/src/main/java/io/gravitee/plugin/repository/internal/RepositoryTypeReader.java
+++ b/gravitee-plugin-repository/src/main/java/io/gravitee/plugin/repository/internal/RepositoryTypeReader.java
@@ -18,7 +18,9 @@ package io.gravitee.plugin.repository.internal;
 import io.gravitee.platform.repository.api.Scope;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.Environment;
+import org.springframework.core.env.PropertySource;
 
 @RequiredArgsConstructor
 @Slf4j
@@ -28,25 +30,39 @@ class RepositoryTypeReader {
 
     String getRepositoryType(Environment environment, Scope scope) {
         String oldKey = scope.getName() + ".type";
-
         String newKey = REPOSITORIES_PREFIX + oldKey;
 
-        String repositoryType = environment.getProperty(newKey);
+        // Check old key first: it may come from an env var override (e.g. gravitee_management_type=jdbc)
+        // which must take priority over the YAML-defined repositories.management.type value.
+        String repositoryType = environment.getProperty(oldKey);
         if (repositoryType != null) {
+            if (isExplicitlyDefined(environment, oldKey)) {
+                log.warn(
+                    "Repository for scope '{}' is configured using the deprecated key '{}'. Please migrate to '{}'.",
+                    scope,
+                    oldKey,
+                    newKey
+                );
+            }
             return repositoryType;
         }
 
-        repositoryType = environment.getProperty(oldKey);
+        return environment.getProperty(newKey);
+    }
 
-        if (repositoryType != null) {
-            log.warn(
-                "Repository for scope '{}' is configured using the deprecated key '{}'. Please migrate to '{}'.",
-                scope,
-                oldKey,
-                newKey
-            );
+    /**
+     * Checks if the key is explicitly defined in a property source (not via the alias).
+     * This avoids false-positive deprecation warnings when the alias resolves the old key
+     * from the new repositories.* format.
+     */
+    private boolean isExplicitlyDefined(Environment environment, String key) {
+        if (environment instanceof ConfigurableEnvironment configEnv) {
+            return configEnv
+                .getPropertySources()
+                .stream()
+                .filter(ps -> !RepositoryAliasPropertySource.PROPERTY_SOURCE_NAME.equals(ps.getName()))
+                .anyMatch(ps -> ps.getProperty(key) != null);
         }
-
-        return repositoryType;
+        return false;
     }
 }

--- a/gravitee-plugin-repository/src/main/java/io/gravitee/plugin/repository/internal/RepositoryTypeReader.java
+++ b/gravitee-plugin-repository/src/main/java/io/gravitee/plugin/repository/internal/RepositoryTypeReader.java
@@ -29,18 +29,18 @@ class RepositoryTypeReader {
     private static final String REPOSITORIES_PREFIX = "repositories.";
 
     String getRepositoryType(Environment environment, Scope scope) {
-        String oldKey = scope.getName() + ".type";
-        String newKey = REPOSITORIES_PREFIX + oldKey;
+        String legacyKey = scope.getName() + ".type";
+        String newKey = REPOSITORIES_PREFIX + legacyKey;
 
-        // Check old key first: it may come from an env var override (e.g. gravitee_management_type=jdbc)
+        // Check legacy key first: it may come from an env var override (e.g. gravitee_management_type=jdbc)
         // which must take priority over the YAML-defined repositories.management.type value.
-        String repositoryType = environment.getProperty(oldKey);
+        String repositoryType = environment.getProperty(legacyKey);
         if (repositoryType != null) {
-            if (isExplicitlyDefined(environment, oldKey)) {
+            if (isExplicitlyDefined(environment, legacyKey)) {
                 log.warn(
                     "Repository for scope '{}' is configured using the deprecated key '{}'. Please migrate to '{}'.",
                     scope,
-                    oldKey,
+                    legacyKey,
                     newKey
                 );
             }
@@ -52,7 +52,7 @@ class RepositoryTypeReader {
 
     /**
      * Checks if the key is explicitly defined in a property source (not via the alias).
-     * This avoids false-positive deprecation warnings when the alias resolves the old key
+     * This avoids false-positive deprecation warnings when the alias resolves the legacy key
      * from the new repositories.* format.
      */
     private boolean isExplicitlyDefined(Environment environment, String key) {

--- a/gravitee-plugin-repository/src/test/java/io/gravitee/plugin/repository/internal/RepositoryAliasPropertySourceTest.java
+++ b/gravitee-plugin-repository/src/test/java/io/gravitee/plugin/repository/internal/RepositoryAliasPropertySourceTest.java
@@ -69,7 +69,7 @@ public class RepositoryAliasPropertySourceTest {
     }
 
     @Test
-    public void should_prefer_short_key_when_both_are_set_in_same_source() {
+    public void should_prefer_legacy_key_when_both_are_set_in_same_source() {
         setProperties(
             Map.of(
                 "management.mongodb.uri",
@@ -168,7 +168,7 @@ public class RepositoryAliasPropertySourceTest {
     }
 
     @Test
-    public void should_let_envvar_with_short_key_override_yaml_with_repositories_prefix() {
+    public void should_let_envvar_with_legacy_key_override_yaml_with_repositories_prefix() {
         Map<String, Object> yamlProps = new HashMap<>();
         yamlProps.put("repositories.management.mongodb.uri", "mongodb://localhost:27017/gravitee");
 
@@ -183,7 +183,7 @@ public class RepositoryAliasPropertySourceTest {
     }
 
     @Test
-    public void should_let_envvar_with_short_key_override_yaml_for_elasticsearch_endpoint() {
+    public void should_let_envvar_with_legacy_key_override_yaml_for_elasticsearch_endpoint() {
         Map<String, Object> yamlProps = new HashMap<>();
         yamlProps.put("repositories.analytics.elasticsearch.endpoints[0]", "http://localhost:9200");
 
@@ -198,7 +198,7 @@ public class RepositoryAliasPropertySourceTest {
     }
 
     @Test
-    public void should_let_envvar_with_short_key_win_even_when_yaml_has_higher_source_priority() {
+    public void should_let_envvar_with_legacy_key_win_even_when_yaml_has_higher_source_priority() {
         Map<String, Object> yamlProps = new HashMap<>();
         yamlProps.put("repositories.management.type", "mongodb");
 

--- a/gravitee-plugin-repository/src/test/java/io/gravitee/plugin/repository/internal/RepositoryAliasPropertySourceTest.java
+++ b/gravitee-plugin-repository/src/test/java/io/gravitee/plugin/repository/internal/RepositoryAliasPropertySourceTest.java
@@ -18,6 +18,7 @@ package io.gravitee.plugin.repository.internal;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
+import java.util.HashMap;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
@@ -68,7 +69,7 @@ public class RepositoryAliasPropertySourceTest {
     }
 
     @Test
-    public void should_prefer_new_prefix_when_both_are_set() {
+    public void should_prefer_short_key_when_both_are_set_in_same_source() {
         setProperties(
             Map.of(
                 "management.mongodb.uri",
@@ -78,7 +79,7 @@ public class RepositoryAliasPropertySourceTest {
             )
         );
 
-        assertEquals("mongodb://newhost:27017/gravitee", environment.getProperty("management.mongodb.uri"));
+        assertEquals("mongodb://oldhost:27017/gravitee", environment.getProperty("management.mongodb.uri"));
     }
 
     @Test
@@ -136,5 +137,78 @@ public class RepositoryAliasPropertySourceTest {
 
         assertEquals("http://es1:9200", environment.getProperty("analytics.elasticsearch.endpoints[0]"));
         assertEquals("http://es2:9200", environment.getProperty("analytics.elasticsearch.endpoints[1]"));
+    }
+
+    @Test
+    public void should_let_envvar_override_yaml_for_repositories_prefixed_key() {
+        Map<String, Object> yamlProps = new HashMap<>();
+        yamlProps.put("repositories.analytics.elasticsearch.endpoints[0]", "http://localhost:9200");
+
+        Map<String, Object> envvarProps = new HashMap<>();
+        envvarProps.put("repositories.analytics.elasticsearch.endpoints[0]", "http://elasticsearch:9200");
+
+        environment.getPropertySources().addFirst(new MapPropertySource("yaml", yamlProps));
+        environment.getPropertySources().addFirst(new MapPropertySource("envvars", envvarProps));
+        environment.getPropertySources().addFirst(new RepositoryAliasPropertySource(environment));
+
+        assertEquals("http://elasticsearch:9200", environment.getProperty("analytics.elasticsearch.endpoints[0]"));
+
+        assertEquals("http://elasticsearch:9200", environment.getProperty("repositories.analytics.elasticsearch.endpoints[0]"));
+    }
+
+    @Test
+    public void should_still_resolve_legacy_analytics_type_without_repositories_prefix() {
+        Map<String, Object> yamlProps = new HashMap<>();
+        yamlProps.put("analytics.type", "elasticsearch");
+
+        environment.getPropertySources().addFirst(new MapPropertySource("yaml", yamlProps));
+        environment.getPropertySources().addFirst(new RepositoryAliasPropertySource(environment));
+
+        assertEquals("elasticsearch", environment.getProperty("analytics.type"));
+    }
+
+    @Test
+    public void should_let_envvar_with_short_key_override_yaml_with_repositories_prefix() {
+        Map<String, Object> yamlProps = new HashMap<>();
+        yamlProps.put("repositories.management.mongodb.uri", "mongodb://localhost:27017/gravitee");
+
+        Map<String, Object> envvarProps = new HashMap<>();
+        envvarProps.put("management.mongodb.uri", "mongodb://mongo:27017/gravitee");
+
+        environment.getPropertySources().addFirst(new MapPropertySource("yaml", yamlProps));
+        environment.getPropertySources().addFirst(new MapPropertySource("envvars", envvarProps));
+        environment.getPropertySources().addFirst(new RepositoryAliasPropertySource(environment));
+
+        assertEquals("mongodb://mongo:27017/gravitee", environment.getProperty("management.mongodb.uri"));
+    }
+
+    @Test
+    public void should_let_envvar_with_short_key_override_yaml_for_elasticsearch_endpoint() {
+        Map<String, Object> yamlProps = new HashMap<>();
+        yamlProps.put("repositories.analytics.elasticsearch.endpoints[0]", "http://localhost:9200");
+
+        Map<String, Object> envvarProps = new HashMap<>();
+        envvarProps.put("analytics.elasticsearch.endpoints[0]", "http://elasticsearch:9200");
+
+        environment.getPropertySources().addFirst(new MapPropertySource("yaml", yamlProps));
+        environment.getPropertySources().addFirst(new MapPropertySource("envvars", envvarProps));
+        environment.getPropertySources().addFirst(new RepositoryAliasPropertySource(environment));
+
+        assertEquals("http://elasticsearch:9200", environment.getProperty("analytics.elasticsearch.endpoints[0]"));
+    }
+
+    @Test
+    public void should_let_envvar_with_short_key_win_even_when_yaml_has_higher_source_priority() {
+        Map<String, Object> yamlProps = new HashMap<>();
+        yamlProps.put("repositories.management.type", "mongodb");
+
+        Map<String, Object> envvarProps = new HashMap<>();
+        envvarProps.put("management.type", "jdbc");
+
+        environment.getPropertySources().addFirst(new MapPropertySource("envvars", envvarProps));
+        environment.getPropertySources().addFirst(new MapPropertySource("yaml", yamlProps));
+        environment.getPropertySources().addFirst(new RepositoryAliasPropertySource(environment));
+
+        assertEquals("jdbc", environment.getProperty("management.type"));
     }
 }

--- a/gravitee-plugin-repository/src/test/java/io/gravitee/plugin/repository/internal/RepositoryTypeReaderTest.java
+++ b/gravitee-plugin-repository/src/test/java/io/gravitee/plugin/repository/internal/RepositoryTypeReaderTest.java
@@ -43,7 +43,7 @@ public class RepositoryTypeReaderTest {
     private final RepositoryTypeReader reader = new RepositoryTypeReader();
 
     @Test
-    public void should_read_from_old_key_first() {
+    public void should_read_from_legacy_key_first() {
         when(environment.getProperty("management.type")).thenReturn("jdbc");
         String type = reader.getRepositoryType(environment, Scope.MANAGEMENT);
 
@@ -51,7 +51,7 @@ public class RepositoryTypeReaderTest {
     }
 
     @Test
-    public void should_fallback_to_new_key_when_old_key_not_set() {
+    public void should_fallback_to_new_key_when_legacy_key_not_set() {
         when(environment.getProperty("management.type")).thenReturn(null);
         when(environment.getProperty("repositories.management.type")).thenReturn("mongodb");
         String type = reader.getRepositoryType(environment, Scope.MANAGEMENT);
@@ -68,7 +68,7 @@ public class RepositoryTypeReaderTest {
     }
 
     @Test
-    public void should_log_warning_when_old_key_is_explicitly_defined() {
+    public void should_log_warning_when_legacy_key_is_explicitly_defined() {
         // Use a real environment so isExplicitlyDefined can iterate property sources
         StandardEnvironment realEnv = new StandardEnvironment();
         realEnv.getPropertySources().addFirst(new MapPropertySource("test", Map.of("management.type", "jdbc")));
@@ -95,7 +95,7 @@ public class RepositoryTypeReaderTest {
     }
 
     @Test
-    public void should_not_log_warning_when_old_key_comes_from_alias() {
+    public void should_not_log_warning_when_legacy_key_comes_from_alias() {
         StandardEnvironment realEnv = new StandardEnvironment();
         realEnv.getPropertySources().addFirst(new MapPropertySource("yaml", Map.of("repositories.management.type", "mongodb")));
         realEnv.getPropertySources().addFirst(new RepositoryAliasPropertySource(realEnv));

--- a/gravitee-plugin-repository/src/test/java/io/gravitee/plugin/repository/internal/RepositoryTypeReaderTest.java
+++ b/gravitee-plugin-repository/src/test/java/io/gravitee/plugin/repository/internal/RepositoryTypeReaderTest.java
@@ -24,13 +24,15 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 import io.gravitee.platform.repository.api.Scope;
-import java.util.List;
+import java.util.Map;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.env.Environment;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.StandardEnvironment;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RepositoryTypeReaderTest {
@@ -41,16 +43,7 @@ public class RepositoryTypeReaderTest {
     private final RepositoryTypeReader reader = new RepositoryTypeReader();
 
     @Test
-    public void scope_should_be_read_from_repositories_section_first() {
-        when(environment.getProperty("repositories.management.type")).thenReturn("mongodb");
-        String type = reader.getRepositoryType(environment, Scope.MANAGEMENT);
-
-        assertEquals("mongodb", type);
-    }
-
-    @Test
-    public void scope_should_be_read_from_old_structure_as_fallback() {
-        when(environment.getProperty("repositories.management.type")).thenReturn(null);
+    public void should_read_from_old_key_first() {
         when(environment.getProperty("management.type")).thenReturn("jdbc");
         String type = reader.getRepositoryType(environment, Scope.MANAGEMENT);
 
@@ -58,35 +51,64 @@ public class RepositoryTypeReaderTest {
     }
 
     @Test
-    public void should_return_null_when_properties_are_missing() {
-        when(environment.getProperty("repositories.management.type")).thenReturn(null);
+    public void should_fallback_to_new_key_when_old_key_not_set() {
         when(environment.getProperty("management.type")).thenReturn(null);
+        when(environment.getProperty("repositories.management.type")).thenReturn("mongodb");
+        String type = reader.getRepositoryType(environment, Scope.MANAGEMENT);
+
+        assertEquals("mongodb", type);
+    }
+
+    @Test
+    public void should_return_null_when_properties_are_missing() {
+        when(environment.getProperty("management.type")).thenReturn(null);
+        when(environment.getProperty("repositories.management.type")).thenReturn(null);
         String type = reader.getRepositoryType(environment, Scope.MANAGEMENT);
         assertNull(type);
     }
 
     @Test
-    public void should_log_warning_when_fallback_is_triggered() {
+    public void should_log_warning_when_old_key_is_explicitly_defined() {
+        // Use a real environment so isExplicitlyDefined can iterate property sources
+        StandardEnvironment realEnv = new StandardEnvironment();
+        realEnv.getPropertySources().addFirst(new MapPropertySource("test", Map.of("management.type", "jdbc")));
+
         Logger logger = (Logger) LoggerFactory.getLogger(RepositoryTypeReader.class);
         ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
         listAppender.start();
         logger.addAppender(listAppender);
 
         try {
-            when(environment.getProperty("repositories.management.type")).thenReturn(null);
-            when(environment.getProperty("management.type")).thenReturn("jdbc");
-            String type = reader.getRepositoryType(environment, Scope.MANAGEMENT);
+            String type = reader.getRepositoryType(realEnv, Scope.MANAGEMENT);
             assertEquals("jdbc", type);
-            List<ILoggingEvent> logs = listAppender.list;
-            assertEquals("Should have logged exactly one warning", 1, logs.size());
+            assertEquals("Should have logged exactly one warning", 1, listAppender.list.size());
 
-            ILoggingEvent logEvent = logs.get(0);
-            assertEquals("Log level should be WARN", Level.WARN, logEvent.getLevel());
+            ILoggingEvent logEvent = listAppender.list.get(0);
+            assertEquals(Level.WARN, logEvent.getLevel());
             assertEquals(
-                "Log message should match expected format",
                 "Repository for scope 'MANAGEMENT' is configured using the deprecated key 'management.type'. Please migrate to 'repositories.management.type'.",
                 logEvent.getFormattedMessage()
             );
+        } finally {
+            logger.detachAppender(listAppender);
+        }
+    }
+
+    @Test
+    public void should_not_log_warning_when_old_key_comes_from_alias() {
+        StandardEnvironment realEnv = new StandardEnvironment();
+        realEnv.getPropertySources().addFirst(new MapPropertySource("yaml", Map.of("repositories.management.type", "mongodb")));
+        realEnv.getPropertySources().addFirst(new RepositoryAliasPropertySource(realEnv));
+
+        Logger logger = (Logger) LoggerFactory.getLogger(RepositoryTypeReader.class);
+        ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+        listAppender.start();
+        logger.addAppender(listAppender);
+
+        try {
+            String type = reader.getRepositoryType(realEnv, Scope.MANAGEMENT);
+            assertEquals("mongodb", type);
+            assertEquals("Should not have logged any warning", 0, listAppender.list.size());
         } finally {
             logger.detachAppender(listAppender);
         }


### PR DESCRIPTION
**Issue**

  https://gravitee.atlassian.net/browse/APIM-11302

  **Description**

  Fix property source priority for repository configuration aliases
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.1.1-fix-apim-11302-v3-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/plugin/gravitee-plugin/5.1.1-fix-apim-11302-v3-SNAPSHOT/gravitee-plugin-5.1.1-fix-apim-11302-v3-SNAPSHOT.zip)
  <!-- Version placeholder end -->
