### PR TITLE
fix(core): log the right file name if not found - main

### DIFF
--- a/gravitee-plugin-core/src/main/java/io/gravitee/plugin/core/api/AbstractConfigurablePluginManager.java
+++ b/gravitee-plugin-core/src/main/java/io/gravitee/plugin/core/api/AbstractConfigurablePluginManager.java
@@ -256,7 +256,7 @@ public abstract class AbstractConfigurablePluginManager<T extends ConfigurablePl
                 String mimeType = Files.probeContentType(file);
                 return "data:" + mimeType + ";base64," + Base64.getEncoder().encodeToString(Files.readAllBytes(file));
             } catch (NoSuchFileException ex) {
-                logger.warn("File not found {}", plugin.path().toString());
+                logger.warn("File not found {}", ex.getFile());
             }
         }
         return null;

--- a/gravitee-plugin-core/src/test/java/io/gravitee/plugin/core/api/AbstractConfigurablePluginManagerTest.java
+++ b/gravitee-plugin-core/src/test/java/io/gravitee/plugin/core/api/AbstractConfigurablePluginManagerTest.java
@@ -19,6 +19,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -32,6 +36,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
@@ -188,10 +193,30 @@ class AbstractConfigurablePluginManagerTest {
 
     @Test
     void should_get_null_if_file_not_found() throws IOException {
-        cut.register(new FakePlugin());
-        properties.put("icon", "images/fake-path.png");
-        final String icon = cut.getIcon(FAKE_PLUGIN);
-        assertNull(icon);
+        Logger logger = (Logger) LoggerFactory.getLogger(AbstractConfigurablePluginManager.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+
+        try {
+            cut.register(new FakePlugin());
+            properties.put("icon", "images/fake-path.png");
+            final String icon = cut.getIcon(FAKE_PLUGIN);
+            assertNull(icon);
+
+            assertTrue(
+                appender.list
+                    .stream()
+                    .anyMatch(
+                        event ->
+                            event.getLevel() == Level.WARN &&
+                            event.getFormattedMessage().startsWith("File not found ") &&
+                            event.getFormattedMessage().contains("fake-path.png")
+                    )
+            );
+        } finally {
+            logger.detachAppender(appender);
+        }
     }
 
     private static class FakePlugin implements ConfigurablePlugin<String> {


### PR DESCRIPTION
**Description**

Log the right file name if not found instead of the the plugin folder name
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.1.2-improve-error-log-in-plugin-manager-main-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/plugin/gravitee-plugin/5.1.2-improve-error-log-in-plugin-manager-main-SNAPSHOT/gravitee-plugin-5.1.2-improve-error-log-in-plugin-manager-main-SNAPSHOT.zip)
  <!-- Version placeholder end -->
