### PR TITLE
fix(annotation-processor): evaluate EL in Set<String> configuration fields (APIM-14232)

### DIFF
--- a/gravitee-plugin-annotation-processors/src/main/java/io/gravitee/plugin/annotation/processor/ConfigurationEvaluatorProcessor.java
+++ b/gravitee-plugin-annotation-processors/src/main/java/io/gravitee/plugin/annotation/processor/ConfigurationEvaluatorProcessor.java
@@ -564,6 +564,7 @@ public class ConfigurationEvaluatorProcessor extends AbstractProcessor {
 
         private final boolean toEval;
         private final boolean toEvalList;
+        private final boolean toEvalSet;
         private final boolean toEvalHeaderList;
         private final boolean toEvalMap;
         private final boolean jsonType;
@@ -588,6 +589,7 @@ public class ConfigurationEvaluatorProcessor extends AbstractProcessor {
             // Check if the type of this field is supported EL to know if it's need to be evaluated by the template engine
             this.toEval = "String".equals(fieldType);
             this.toEvalList = "ListString".equals(fieldType);
+            this.toEvalSet = "SetString".equals(fieldType);
             this.toEvalHeaderList = "ListHeader".equals(fieldType);
             this.toEvalMap = "MapString".equals(fieldType);
             this.jsonType = isJsonTypeInfoProperty(field, jsonTypeClass);
@@ -636,6 +638,8 @@ public class ConfigurationEvaluatorProcessor extends AbstractProcessor {
                 return "String";
             } else if (is(field.asType(), Boolean.class) || is(field.asType(), boolean.class)) {
                 return "Boolean";
+            } else if (isStringSet(field.asType(), elementUtils, typeUtils)) {
+                return "SetString";
             } else if (is(field.asType(), Set.class)) {
                 return "Set";
             } else if (isStringList(field.asType(), elementUtils, typeUtils)) {
@@ -675,6 +679,19 @@ public class ConfigurationEvaluatorProcessor extends AbstractProcessor {
 
         private static boolean isStringList(TypeMirror type, Elements elementUtils, Types typeUtils) {
             if (!(type instanceof DeclaredType) || ((DeclaredType) type).getTypeArguments().size() != 1) {
+                return false;
+            }
+
+            TypeMirror firstType = ((DeclaredType) type).getTypeArguments().get(0);
+            if (firstType == null) {
+                return false;
+            }
+            var StringElem = elementUtils.getTypeElement("java.lang.String");
+            return typeUtils.isSameType(firstType, StringElem.asType());
+        }
+
+        private static boolean isStringSet(TypeMirror type, Elements elementUtils, Types typeUtils) {
+            if (!is(type, Set.class) || !(type instanceof DeclaredType) || ((DeclaredType) type).getTypeArguments().size() != 1) {
                 return false;
             }
 

--- a/gravitee-plugin-annotation-processors/src/main/resources/templates/evalField.mustache
+++ b/gravitee-plugin-annotation-processors/src/main/resources/templates/evalField.mustache
@@ -8,6 +8,10 @@
                 toEvalList.add(
                     eval{{fieldType}}Property("{{fieldName}}", {{originalConfigurationName}}.{{fieldGetter}}(), currentAttributePrefix, baseExecutionContext)
                 {{/toEvalList}}
+                {{#toEvalSet}}
+                toEvalSet.add(
+                    eval{{fieldType}}Property("{{fieldName}}", {{originalConfigurationName}}.{{fieldGetter}}(), currentAttributePrefix, baseExecutionContext)
+                {{/toEvalSet}}
                 {{#toEvalHeaderList}}
                     toEvalHeaderList.add(
                     eval{{fieldType}}Property("{{fieldName}}", {{originalConfigurationName}}.{{fieldGetter}}(), currentAttributePrefix, baseExecutionContext)
@@ -18,12 +22,14 @@
                 {{/toEvalMap}}
                 {{^toEval}}
                     {{^toEvalList}}
+                        {{^toEvalSet}}
                         {{^toEvalHeaderList}}
                             {{^toEvalMap}}
                     {{evaluatedConfigurationName}}.{{fieldSetter}}(
                     eval{{fieldType}}Property("{{fieldName}}", {{originalConfigurationName}}.{{fieldGetter}}(), {{#fieldClass}}{{fieldClass}}.class, {{/fieldClass}}currentAttributePrefix, baseExecutionContext)
                             {{/toEvalMap}}
                         {{/toEvalHeaderList}}
+                        {{/toEvalSet}}
                     {{/toEvalList}}
                 {{/toEval}}
                 {{#toEval}}
@@ -32,6 +38,9 @@
                 {{#toEvalList}}
                     .doOnSuccess(value -> {{evaluatedConfigurationName}}.{{fieldSetter}}(value))
                 {{/toEvalList}}
+                {{#toEvalSet}}
+                    .doOnSuccess(value -> {{evaluatedConfigurationName}}.{{fieldSetter}}(value))
+                {{/toEvalSet}}
                 {{#toEvalHeaderList}}
                     .doOnSuccess(value -> {{evaluatedConfigurationName}}.{{fieldSetter}}(value))
                 {{/toEvalHeaderList}}
@@ -50,6 +59,11 @@
                     eval{{fieldType}}Property("{{fieldName}}", {{originalConfigurationName}}.{{fieldGetter}}(), currentAttributePrefix, deploymentContext)
                     .doOnSuccess(value -> {{evaluatedConfigurationName}}.{{fieldSetter}}(value)));
                 {{/toEvalList}}
+                {{#toEvalSet}}
+                    toEvalSet.add(
+                    eval{{fieldType}}Property("{{fieldName}}", {{originalConfigurationName}}.{{fieldGetter}}(), currentAttributePrefix, deploymentContext)
+                    .doOnSuccess(value -> {{evaluatedConfigurationName}}.{{fieldSetter}}(value)));
+                {{/toEvalSet}}
                 {{#toEvalHeaderList}}
                     toEvalHeaderList.add(
                     eval{{fieldType}}Property("{{fieldName}}", {{originalConfigurationName}}.{{fieldGetter}}(), currentAttributePrefix, deploymentContext)

--- a/gravitee-plugin-annotation-processors/src/main/resources/templates/evaluatorFooter.mustache
+++ b/gravitee-plugin-annotation-processors/src/main/resources/templates/evaluatorFooter.mustache
@@ -2,10 +2,11 @@
         // Evaluate properties that needs EL, validate evaluatedConf and returns it
         Completable toEvalCompletable = Flowable.fromIterable(toEval).concatMapMaybe(m -> m).ignoreElements();
         Completable toEvalListCompletable = Flowable.fromIterable(toEvalList).concatMapMaybe(m -> m).ignoreElements();
+        Completable toEvalSetCompletable = Flowable.fromIterable(toEvalSet).concatMapMaybe(m -> m).ignoreElements();
         Completable toEvalHeaderListCompletable = Flowable.fromIterable(toEvalHeaderList).concatMapMaybe(m -> m).ignoreElements();
         Completable toEvalMapCompletable = Flowable.fromIterable(toEvalMap).concatMapMaybe(m -> m).ignoreElements();
 
-        return Completable.concatArray(toEvalCompletable, toEvalListCompletable, toEvalHeaderListCompletable, toEvalMapCompletable)
+        return Completable.concatArray(toEvalCompletable, toEvalListCompletable, toEvalSetCompletable, toEvalHeaderListCompletable, toEvalMapCompletable)
             .andThen(Completable.fromRunnable(() -> validateConfiguration(evaluatedConfiguration)))
             .andThen(Completable.fromRunnable(() -> {
                 if(baseExecutionContext != null) {

--- a/gravitee-plugin-annotation-processors/src/main/resources/templates/evaluatorHeader.mustache
+++ b/gravitee-plugin-annotation-processors/src/main/resources/templates/evaluatorHeader.mustache
@@ -39,6 +39,7 @@ import org.slf4j.Logger;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -236,6 +237,45 @@ public class {{evaluatorSimpleClassName}} {
                 .eval(v, String.class)
                 .doOnError(throwable -> log.error("Unable to evaluate property [{}] with expression [{}].", name, v, throwable)))
             .toList()
+            .toMaybe();
+    }
+
+    private Maybe<Set<String>> evalSetStringProperty(String name, Set<String> value, String attributePrefix, BaseExecutionContext ctx) {
+        List<String> attribute = ctx.getAttributeAsList(buildAttributeName(attributePrefix, name));
+        if (attribute != null) {
+            //If a value is found for this attribute, override the original value with it
+            value = new LinkedHashSet<>(attribute);
+        }
+        //If value is null, return empty
+        if(value == null) {
+            return Maybe.empty();
+        }
+
+        //Then check EL
+        return Flowable.fromIterable(value).filter(Objects::nonNull)
+            .flatMapMaybe(v -> ctx
+                .getTemplateEngine()
+                .eval(v, String.class)
+                .doOnError(throwable -> ctx.withLogger(log).error("Unable to evaluate property [{}] with expression [{}].", name, v, throwable)))
+            .toList()
+            .map(list -> (Set<String>) new LinkedHashSet<>(list))
+            .toMaybe();
+    }
+
+    private Maybe<Set<String>> evalSetStringProperty(String name, Set<String> value, String attributePrefix, DeploymentContext ctx) {
+        //If value is null, return empty
+        if(value == null) {
+            return Maybe.empty();
+        }
+
+        //Then check EL
+        return Flowable.fromIterable(value).filter(Objects::nonNull)
+            .flatMapMaybe(v -> ctx
+                .getTemplateEngine()
+                .eval(v, String.class)
+                .doOnError(throwable -> log.error("Unable to evaluate property [{}] with expression [{}].", name, v, throwable)))
+            .toList()
+            .map(list -> (Set<String>) new LinkedHashSet<>(list))
             .toMaybe();
     }
 
@@ -459,5 +499,6 @@ public class {{evaluatorSimpleClassName}} {
 
         List<Maybe<String>> toEval = new ArrayList<>();
         List<Maybe<List<String>>> toEvalList = new ArrayList<>();
+        List<Maybe<Set<String>>> toEvalSet = new ArrayList<>();
         List<Maybe<List<HttpHeader>>> toEvalHeaderList = new ArrayList<>();
         List<Maybe<Map<String, String>>> toEvalMap = new ArrayList<>();

--- a/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/ConfigurationEvaluatorGeneratedTest.java
+++ b/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/ConfigurationEvaluatorGeneratedTest.java
@@ -138,6 +138,26 @@ public class ConfigurationEvaluatorGeneratedTest {
     }
 
     @Test
+    public void should_resolve_el_in_set_topics() {
+        // Reproduces APIM-14232: EL expressions in Set<String> topics must be evaluated through the template engine
+        TestConfiguration configuration = new TestConfiguration();
+        configuration.getConsumer().setTopics(Set.of("{#api.properties['producerTopic']}", "static-topic"));
+        evaluator = new TestConfigurationEvaluator(configuration);
+
+        var spiedTemplateEngine = spy(new DefaultTemplateEngine());
+        when(spiedTemplateEngine.eval("{#api.properties['producerTopic']}", String.class)).thenReturn(Maybe.just("resolved-topic"));
+
+        evaluator
+            .eval(new DefaultExecutionContext(spiedTemplateEngine))
+            .test()
+            .assertComplete()
+            .assertValue(testConfiguration -> {
+                assertThat(testConfiguration.getConsumer().getTopics()).containsExactlyInAnyOrder("resolved-topic", "static-topic");
+                return true;
+            });
+    }
+
+    @Test
     public void should_cache_evaluated_configuration() {
         when(templateEngine.eval("none", String.class)).thenReturn(Maybe.just("latest"));
         when(templateEngine.eval("password", String.class)).thenReturn(Maybe.just("password"));
@@ -149,6 +169,8 @@ public class ConfigurationEvaluatorGeneratedTest {
         when(templateEngine.eval("{#secrets.get('/vault/secret/test:password')}", String.class)).thenReturn(Maybe.just("password"));
         when(templateEngine.eval("{#secrets.get('/vault/secret/test:token')}", String.class)).thenReturn(Maybe.just("my_secret_token"));
         when(templateEngine.eval("{#secrets.get('/vault/secret/test:extension')}", String.class)).thenReturn(Maybe.just("extension_value"));
+        when(templateEngine.eval("topic1", String.class)).thenReturn(Maybe.just("topic1"));
+        when(templateEngine.eval("topic2", String.class)).thenReturn(Maybe.just("topic2"));
         when(templateEngine.getTemplateContext()).thenReturn(templateContext);
         Map<String, Object> contextMap = new HashMap<>();
         contextMap.put("gravitee.attributes.endpoint.test.protocol", "SSL");

--- a/gravitee-plugin-annotation-processors/src/test/resources/test/TestConfigurationEvaluator.java
+++ b/gravitee-plugin-annotation-processors/src/test/resources/test/TestConfigurationEvaluator.java
@@ -39,6 +39,7 @@ import org.slf4j.Logger;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -236,6 +237,45 @@ public class TestConfigurationEvaluator {
                         .eval(v, String.class)
                         .doOnError(throwable -> log.error("Unable to evaluate property [{}] with expression [{}].", name, v, throwable)))
                 .toList()
+                .toMaybe();
+    }
+
+    private Maybe<Set<String>> evalSetStringProperty(String name, Set<String> value, String attributePrefix, BaseExecutionContext ctx) {
+        List<String> attribute = ctx.getAttributeAsList(buildAttributeName(attributePrefix, name));
+        if (attribute != null) {
+            //If a value is found for this attribute, override the original value with it
+            value = new LinkedHashSet<>(attribute);
+        }
+        //If value is null, return empty
+        if(value == null) {
+            return Maybe.empty();
+        }
+
+        //Then check EL
+        return Flowable.fromIterable(value).filter(Objects::nonNull)
+                .flatMapMaybe(v -> ctx
+                        .getTemplateEngine()
+                        .eval(v, String.class)
+                        .doOnError(throwable -> ctx.withLogger(log).error("Unable to evaluate property [{}] with expression [{}].", name, v, throwable)))
+                .toList()
+                .map(list -> (Set<String>) new LinkedHashSet<>(list))
+                .toMaybe();
+    }
+
+    private Maybe<Set<String>> evalSetStringProperty(String name, Set<String> value, String attributePrefix, DeploymentContext ctx) {
+        //If value is null, return empty
+        if(value == null) {
+            return Maybe.empty();
+        }
+
+        //Then check EL
+        return Flowable.fromIterable(value).filter(Objects::nonNull)
+                .flatMapMaybe(v -> ctx
+                        .getTemplateEngine()
+                        .eval(v, String.class)
+                        .doOnError(throwable -> log.error("Unable to evaluate property [{}] with expression [{}].", name, v, throwable)))
+                .toList()
+                .map(list -> (Set<String>) new LinkedHashSet<>(list))
                 .toMaybe();
     }
 
@@ -459,6 +499,7 @@ public class TestConfigurationEvaluator {
 
         List<Maybe<String>> toEval = new ArrayList<>();
         List<Maybe<List<String>>> toEvalList = new ArrayList<>();
+        List<Maybe<Set<String>>> toEvalSet = new ArrayList<>();
         List<Maybe<List<HttpHeader>>> toEvalHeaderList = new ArrayList<>();
         List<Maybe<Map<String, String>>> toEvalMap = new ArrayList<>();
         //Field protocol
@@ -510,10 +551,14 @@ public class TestConfigurationEvaluator {
             }
             //Field topics
             if(baseExecutionContext != null) {
-                evaluatedConfiguration.getConsumer().setTopics(
-                        evalSetProperty("topics", configuration.getConsumer().getTopics(), currentAttributePrefix, baseExecutionContext)
+                toEvalSet.add(
+                        evalSetStringProperty("topics", configuration.getConsumer().getTopics(), currentAttributePrefix, baseExecutionContext)
+                                .doOnSuccess(value -> evaluatedConfiguration.getConsumer().setTopics(value))
                 );
             } else if(deploymentContext != null) {
+                toEvalSet.add(
+                        evalSetStringProperty("topics", configuration.getConsumer().getTopics(), currentAttributePrefix, deploymentContext)
+                                .doOnSuccess(value -> evaluatedConfiguration.getConsumer().setTopics(value)));
             }
             //Field topicPattern
             if(baseExecutionContext != null) {
@@ -1092,10 +1137,11 @@ public class TestConfigurationEvaluator {
         // Evaluate properties that needs EL, validate evaluatedConf and returns it
         Completable toEvalCompletable = Flowable.fromIterable(toEval).concatMapMaybe(m -> m).ignoreElements();
         Completable toEvalListCompletable = Flowable.fromIterable(toEvalList).concatMapMaybe(m -> m).ignoreElements();
+        Completable toEvalSetCompletable = Flowable.fromIterable(toEvalSet).concatMapMaybe(m -> m).ignoreElements();
         Completable toEvalHeaderListCompletable = Flowable.fromIterable(toEvalHeaderList).concatMapMaybe(m -> m).ignoreElements();
         Completable toEvalMapCompletable = Flowable.fromIterable(toEvalMap).concatMapMaybe(m -> m).ignoreElements();
 
-        return Completable.concatArray(toEvalCompletable, toEvalListCompletable, toEvalHeaderListCompletable, toEvalMapCompletable)
+        return Completable.concatArray(toEvalCompletable, toEvalListCompletable, toEvalSetCompletable, toEvalHeaderListCompletable, toEvalMapCompletable)
             .andThen(Completable.fromRunnable(() -> validateConfiguration(evaluatedConfiguration)))
             .andThen(Completable.fromRunnable(() -> {
                 if(baseExecutionContext != null) {


### PR DESCRIPTION
## Problem

`Set<String>` fields on `@ConfigurationEvaluator` configurations are dispatched to `evalSetProperty`, which only applies attribute overrides and returns the raw value — **the template engine is never invoked**. EL expressions in such fields are therefore sent verbatim to the connector instead of being resolved.

This is the root cause of **[APIM-14232](https://gravitee.atlassian.net/browse/APIM-14232)** ("EL not supported for Kafka producer topics"): a Kafka endpoint's `producer.topics` and `consumer.topics` are both `Set<String>`, so an expression like `{#api.properties['producerTopic']}` is passed to Kafka as a literal topic name. The gap is generic — it affects any connector with a `Set<String>` config field (only `String` and `List<String>` had EL-aware handlers).

## Fix

Add an EL-aware path for `Set<String>` in the annotation processor, mirroring the existing `List<String>` handling:

- Detect `Set<String>` as a dedicated `"SetString"` field type (checked **ahead** of the generic `Set` branch).
- Generate `evalSetStringProperty` (`BaseExecutionContext` + `DeploymentContext` overloads) which evaluates each element through the template engine while preserving attribute-override semantics.
- Wire it through `evalField` / footer via a new `toEvalSet` accumulator.
- Non-`String` sets (`Set<SomeEnum>`, …) keep the existing non-EL `evalSetProperty` path — no behavior change.

## Tests

- Updated the generator golden file (`TestConfigurationEvaluator.java`); `ConfigurationEvaluatorProcessorTest` AST-equivalence check confirms the generated code matches exactly.
- Added `should_resolve_el_in_set_topics` proving EL now resolves in `Set<String>` topics.
- Updated `should_cache_evaluated_configuration` (topics now flow through EL).
- `mvn -pl gravitee-plugin-annotation-processors test` → **7/7 green**.

## Downstream

Connectors pick this up after their `gravitee-plugin` version is bumped and they are rebuilt (e.g. `gravitee-endpoint-kafka` for the original Kafka topics report).

Ref: [APIM-14232](https://gravitee.atlassian.net/browse/APIM-14232)

[APIM-14232]: https://gravitee.atlassian.net/browse/APIM-14232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APIM-14232]: https://gravitee.atlassian.net/browse/APIM-14232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ