### PR TITLE
fix(annotation-processor): evaluate fields inherited from a superclass

### DIFF
--- a/gravitee-plugin-annotation-processors/src/main/java/io/gravitee/plugin/annotation/processor/ConfigurationEvaluatorProcessor.java
+++ b/gravitee-plugin-annotation-processors/src/main/java/io/gravitee/plugin/annotation/processor/ConfigurationEvaluatorProcessor.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -315,8 +316,7 @@ public class ConfigurationEvaluatorProcessor extends AbstractProcessor {
     ) {
         // 3 things to manage : fields, inner class and object
         // We need to exclude the "builder" part if present
-        List<VariableElement> fields = elementUtils
-            .getAllMembers(currentElement)
+        List<VariableElement> fields = collectFieldsIncludingInheritedPrivate(currentElement)
             .stream()
             .filter(
                 element ->
@@ -486,6 +486,52 @@ public class ConfigurationEvaluatorProcessor extends AbstractProcessor {
 
             mustacheParams.mClose().execute(writer, scopes);
         });
+    }
+
+    /**
+     * Collects the fields to evaluate for the given type, including private fields declared in superclasses.
+     * <p>
+     * {@link Elements#getAllMembers(TypeElement)} only returns members that are <em>inherited</em> in the JLS
+     * sense, which excludes private fields declared in superclasses (private members are never inherited).
+     * A configuration class that simply extends a base class — typically coming from another module/jar — would
+     * therefore expose none of the base's fields and would generate an empty evaluator. We walk the superclass
+     * hierarchy to recover those privately-declared fields.
+     * <p>
+     * Classes annotated with {@link JsonTypeInfo} are intentionally <strong>not</strong> traversed: their fields
+     * are already handled by the dedicated polymorphic ({@link JsonSubTypes}) processing and must not be flattened
+     * into the subtype here, otherwise base fields (e.g. the discriminator or a common {@code alias}) would be
+     * emitted twice.
+     */
+    private List<Element> collectFieldsIncludingInheritedPrivate(TypeElement type) {
+        List<Element> members = new ArrayList<>(elementUtils.getAllMembers(type));
+
+        Set<String> knownFieldNames = members
+            .stream()
+            .filter(element -> element.getKind() == ElementKind.FIELD)
+            .map(element -> element.getSimpleName().toString())
+            .collect(Collectors.toCollection(HashSet::new));
+
+        TypeMirror superclass = type.getSuperclass();
+        while (superclass.getKind() != TypeKind.NONE) {
+            Element superElement = typeUtils.asElement(superclass);
+            if (!(superElement instanceof TypeElement superType)) {
+                break;
+            }
+            if ("java.lang.Object".contentEquals(superType.getQualifiedName()) || superType.getAnnotation(JsonTypeInfo.class) != null) {
+                break;
+            }
+            superType
+                .getEnclosedElements()
+                .stream()
+                .filter(element -> element.getKind() == ElementKind.FIELD)
+                // Only add fields not already provided by getAllMembers() (i.e. the private ones); a field
+                // redeclared in a subclass keeps the subclass declaration.
+                .filter(element -> knownFieldNames.add(element.getSimpleName().toString()))
+                .forEach(members::add);
+            superclass = superType.getSuperclass();
+        }
+
+        return members;
     }
 
     private boolean isConstant(Element element) {

--- a/gravitee-plugin-annotation-processors/src/main/java/io/gravitee/plugin/annotation/processor/ConfigurationEvaluatorProcessor.java
+++ b/gravitee-plugin-annotation-processors/src/main/java/io/gravitee/plugin/annotation/processor/ConfigurationEvaluatorProcessor.java
@@ -520,14 +520,13 @@ public class ConfigurationEvaluatorProcessor extends AbstractProcessor {
             if ("java.lang.Object".contentEquals(superType.getQualifiedName()) || superType.getAnnotation(JsonTypeInfo.class) != null) {
                 break;
             }
-            superType
-                .getEnclosedElements()
-                .stream()
-                .filter(element -> element.getKind() == ElementKind.FIELD)
+            for (Element element : superType.getEnclosedElements()) {
                 // Only add fields not already provided by getAllMembers() (i.e. the private ones); a field
                 // redeclared in a subclass keeps the subclass declaration.
-                .filter(element -> knownFieldNames.add(element.getSimpleName().toString()))
-                .forEach(members::add);
+                if (element.getKind() == ElementKind.FIELD && knownFieldNames.add(element.getSimpleName().toString())) {
+                    members.add(element);
+                }
+            }
             superclass = superType.getSuperclass();
         }
 

--- a/gravitee-plugin-annotation-processors/src/main/java/io/gravitee/plugin/annotation/processor/ConfigurationEvaluatorProcessor.java
+++ b/gravitee-plugin-annotation-processors/src/main/java/io/gravitee/plugin/annotation/processor/ConfigurationEvaluatorProcessor.java
@@ -320,12 +320,10 @@ public class ConfigurationEvaluatorProcessor extends AbstractProcessor {
             .stream()
             .filter(
                 element ->
-                    element.getKind() == ElementKind.FIELD &&
                     !element.getSimpleName().toString().contains("Builder") &&
                     !isConstant(element) &&
                     !excludedFields.contains(element.getSimpleName().toString())
             )
-            .map(VariableElement.class::cast)
             .toList();
 
         Map<Boolean, List<FieldProperty>> convertedFields = fields
@@ -502,13 +500,17 @@ public class ConfigurationEvaluatorProcessor extends AbstractProcessor {
      * into the subtype here, otherwise base fields (e.g. the discriminator or a common {@code alias}) would be
      * emitted twice.
      */
-    private List<Element> collectFieldsIncludingInheritedPrivate(TypeElement type) {
-        List<Element> members = new ArrayList<>(elementUtils.getAllMembers(type));
-
-        Set<String> knownFieldNames = members
+    private List<VariableElement> collectFieldsIncludingInheritedPrivate(TypeElement type) {
+        List<VariableElement> fields = elementUtils
+            .getAllMembers(type)
             .stream()
             .filter(element -> element.getKind() == ElementKind.FIELD)
-            .map(element -> element.getSimpleName().toString())
+            .map(VariableElement.class::cast)
+            .collect(Collectors.toCollection(ArrayList::new));
+
+        Set<String> knownFieldNames = fields
+            .stream()
+            .map(field -> field.getSimpleName().toString())
             .collect(Collectors.toCollection(HashSet::new));
 
         TypeMirror superclass = type.getSuperclass();
@@ -524,13 +526,13 @@ public class ConfigurationEvaluatorProcessor extends AbstractProcessor {
                 // Only add fields not already provided by getAllMembers() (i.e. the private ones); a field
                 // redeclared in a subclass keeps the subclass declaration.
                 if (element.getKind() == ElementKind.FIELD && knownFieldNames.add(element.getSimpleName().toString())) {
-                    members.add(element);
+                    fields.add((VariableElement) element);
                 }
             }
             superclass = superType.getSuperclass();
         }
 
-        return members;
+        return fields;
     }
 
     private boolean isConstant(Element element) {

--- a/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/ConfigurationEvaluatorProcessorTest.java
+++ b/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/ConfigurationEvaluatorProcessorTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.truth.StringSubject;
 import com.google.testing.compile.Compilation;
 import com.google.testing.compile.CompilationSubject;
 import com.google.testing.compile.JavaFileObjectSubject;
@@ -112,17 +113,18 @@ public class ConfigurationEvaluatorProcessorTest {
         CompilationSubject.assertThat(compilation).succeeded();
 
         // Verify the generated evaluator handles both the inherited fields and the child's own field.
-        JavaFileObjectSubject evaluator = CompilationSubject.assertThat(compilation).generatedSourceFile(
-            "io.gravitee.plugin.annotation.processor.inheritance.ChildSharedConfigurationEvaluator"
-        );
-        evaluator.contentsAsUtf8String().contains("evalStringProperty(\"target\"");
-        evaluator.contentsAsUtf8String().contains("configuration.getTarget()");
-        evaluator.contentsAsUtf8String().contains("evalBooleanProperty(\"enabled\"");
-        evaluator.contentsAsUtf8String().contains("configuration.isEnabled()");
-        evaluator.contentsAsUtf8String().contains("evalIntegerProperty(\"weight\"");
-        evaluator.contentsAsUtf8String().contains("configuration.getWeight()");
-        evaluator.contentsAsUtf8String().contains("evalStringProperty(\"childOnly\"");
-        evaluator.contentsAsUtf8String().contains("configuration.getChildOnly()");
+        // StringSubject#contains is a Truth assertion that fails the test if the content is missing.
+        StringSubject evaluator = CompilationSubject.assertThat(compilation)
+            .generatedSourceFile("io.gravitee.plugin.annotation.processor.inheritance.ChildSharedConfigurationEvaluator")
+            .contentsAsUtf8String();
+        evaluator.contains("evalStringProperty(\"target\"");
+        evaluator.contains("configuration.getTarget()");
+        evaluator.contains("evalBooleanProperty(\"enabled\"");
+        evaluator.contains("configuration.isEnabled()");
+        evaluator.contains("evalIntegerProperty(\"weight\"");
+        evaluator.contains("configuration.getWeight()");
+        evaluator.contains("evalStringProperty(\"childOnly\"");
+        evaluator.contains("configuration.getChildOnly()");
     }
 
     private static List<JavaFileObject> readJavaFilesFromFolder(String folderPath) throws IOException {

--- a/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/ConfigurationEvaluatorProcessorTest.java
+++ b/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/ConfigurationEvaluatorProcessorTest.java
@@ -66,6 +66,65 @@ public class ConfigurationEvaluatorProcessorTest {
         JavaFileObjectSubject.assertThat(generatedSourceFile.get()).hasSourceEquivalentTo(RESULT);
     }
 
+    /**
+     * Regression test: when {@code @ConfigurationEvaluator} is placed on a class that declares no field of its own
+     * but inherits all of them from a (private-field) superclass — typically a base shared-configuration class
+     * coming from another module/jar — the processor must still generate an evaluator that handles the inherited
+     * fields. Before the fix, {@code Elements.getAllMembers()} dropped the inherited private fields and the
+     * generated evaluator was empty.
+     */
+    @Test
+    public void shouldEvaluateFieldsInheritedFromSuperclass() {
+        // Base class lives in its own package to mimic a class coming from another jar. It is NOT annotated and
+        // exposes its fields only through getters/setters, the fields themselves being private.
+        JavaFileObject base = JavaFileObjects.forSourceLines(
+            "io.gravitee.plugin.annotation.processor.inheritance.base.BaseSharedConfiguration",
+            "package io.gravitee.plugin.annotation.processor.inheritance.base;",
+            "public class BaseSharedConfiguration {",
+            "    private String target;",
+            "    private boolean enabled;",
+            "    private Integer weight;",
+            "    public String getTarget() { return target; }",
+            "    public void setTarget(String target) { this.target = target; }",
+            "    public boolean isEnabled() { return enabled; }",
+            "    public void setEnabled(boolean enabled) { this.enabled = enabled; }",
+            "    public Integer getWeight() { return weight; }",
+            "    public void setWeight(Integer weight) { this.weight = weight; }",
+            "}"
+        );
+
+        // Annotated class declares a single field of its own and inherits the rest from the base class.
+        JavaFileObject child = JavaFileObjects.forSourceLines(
+            "io.gravitee.plugin.annotation.processor.inheritance.ChildSharedConfiguration",
+            "package io.gravitee.plugin.annotation.processor.inheritance;",
+            "import io.gravitee.plugin.annotation.ConfigurationEvaluator;",
+            "import io.gravitee.plugin.annotation.processor.inheritance.base.BaseSharedConfiguration;",
+            "@ConfigurationEvaluator(attributePrefix = \"gravitee.attributes.endpoint.child\")",
+            "public class ChildSharedConfiguration extends BaseSharedConfiguration {",
+            "    private String childOnly;",
+            "    public String getChildOnly() { return childOnly; }",
+            "    public void setChildOnly(String childOnly) { this.childOnly = childOnly; }",
+            "}"
+        );
+
+        // Run
+        Compilation compilation = javac().withProcessors(new ConfigurationEvaluatorProcessor()).compile(base, child);
+        CompilationSubject.assertThat(compilation).succeeded();
+
+        // Verify the generated evaluator handles both the inherited fields and the child's own field.
+        JavaFileObjectSubject evaluator = CompilationSubject.assertThat(compilation).generatedSourceFile(
+            "io.gravitee.plugin.annotation.processor.inheritance.ChildSharedConfigurationEvaluator"
+        );
+        evaluator.contentsAsUtf8String().contains("evalStringProperty(\"target\"");
+        evaluator.contentsAsUtf8String().contains("configuration.getTarget()");
+        evaluator.contentsAsUtf8String().contains("evalBooleanProperty(\"enabled\"");
+        evaluator.contentsAsUtf8String().contains("configuration.isEnabled()");
+        evaluator.contentsAsUtf8String().contains("evalIntegerProperty(\"weight\"");
+        evaluator.contentsAsUtf8String().contains("configuration.getWeight()");
+        evaluator.contentsAsUtf8String().contains("evalStringProperty(\"childOnly\"");
+        evaluator.contentsAsUtf8String().contains("configuration.getChildOnly()");
+    }
+
     private static List<JavaFileObject> readJavaFilesFromFolder(String folderPath) throws IOException {
         List<JavaFileObject> javaFileObjects = new ArrayList<>();
 


### PR DESCRIPTION
## Problem

`@ConfigurationEvaluator` on a class that declares no fields of its own and only **extends** a base configuration (typically from another jar) produced an **empty** evaluator — no fields evaluated.

Root cause: the processor collected fields with `Elements.getAllMembers()`, which only returns *inherited* members in the JLS sense. Private fields are never inherited, and config base classes expose their fields as `private` + getters/setters, so all of them were dropped.

## Fix

Walk the superclass hierarchy and recover the privately-declared fields that `getAllMembers()` omits (deduped by name; a subclass redeclaration wins). The walk **stops at `@JsonTypeInfo` base classes** so the existing polymorphic (`JsonSubTypes`) handling is untouched.

## Verification

- New regression test: a config inheriting all its fields from a (private-field) superclass now generates a non-empty evaluator.
- Existing golden-file test still passes (polymorphic SSL/SASL handling unchanged).
- Controlled diff on the kafka endpoint at a fixed processor version (without vs with the fix): generated evaluators are **byte-for-byte identical** — confirms no behavior change for configs that don't rely on inherited fields.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.1.4-fix-configuration-evaluator-inherited-fields-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/plugin/gravitee-plugin/5.1.4-fix-configuration-evaluator-inherited-fields-SNAPSHOT/gravitee-plugin-5.1.4-fix-configuration-evaluator-inherited-fields-SNAPSHOT.zip)
  <!-- Version placeholder end -->
