### PR TITLE
fix(annotation-processor): evaluate EL in fields of List<CustomObject> elements

### DIFF
--- a/gravitee-plugin-annotation-processors/src/main/java/io/gravitee/plugin/annotation/processor/ConfigurationEvaluatorProcessor.java
+++ b/gravitee-plugin-annotation-processors/src/main/java/io/gravitee/plugin/annotation/processor/ConfigurationEvaluatorProcessor.java
@@ -340,9 +340,30 @@ public class ConfigurationEvaluatorProcessor extends AbstractProcessor {
 
         Map<Boolean, List<FieldProperty>> convertedFields = fields
             .stream()
-            .map(field ->
-                new FieldProperty(field, elementUtils, typeUtils, evaluatedConfigurationName, originalConfigurationName, jsonTypeClass)
-            )
+            .map(field -> {
+                FieldProperty fieldProperty = new FieldProperty(
+                    field,
+                    elementUtils,
+                    typeUtils,
+                    evaluatedConfigurationName,
+                    originalConfigurationName,
+                    jsonTypeClass
+                );
+                // Lists of complex objects are mutated element by element below, so the whole-list
+                // fallback must read from the evaluated clone: reading from the original configuration
+                // would alias the clone's list to the original one and mutate the original elements
+                if ("List".equals(fieldProperty.getFieldType()) && getComplexListElementType(field) != null) {
+                    return new FieldProperty(
+                        field,
+                        elementUtils,
+                        typeUtils,
+                        evaluatedConfigurationName,
+                        evaluatedConfigurationName,
+                        jsonTypeClass
+                    );
+                }
+                return fieldProperty;
+            })
             .collect(Collectors.partitioningBy(fieldProperty -> "Object".equals(fieldProperty.getFieldType())));
 
         List<TypeElement> classes = elementUtils

--- a/gravitee-plugin-annotation-processors/src/main/java/io/gravitee/plugin/annotation/processor/ConfigurationEvaluatorProcessor.java
+++ b/gravitee-plugin-annotation-processors/src/main/java/io/gravitee/plugin/annotation/processor/ConfigurationEvaluatorProcessor.java
@@ -281,6 +281,8 @@ public class ConfigurationEvaluatorProcessor extends AbstractProcessor {
             Mustache mSubTypeFooter = mf.compile("templates/evalSubTypeFooter.mustache");
             Mustache mSubTypeCaseHeader = mf.compile("templates/evalSubTypeCaseHeader.mustache");
             Mustache mSubTypeCaseFooter = mf.compile("templates/evalSubTypeCaseFooter.mustache");
+            Mustache mListObjectHeader = mf.compile("templates/evalListObjectHeader.mustache");
+            Mustache mListObjectFooter = mf.compile("templates/evalListObjectFooter.mustache");
 
             //First header
             mHeader.execute(out, scopes);
@@ -288,7 +290,17 @@ public class ConfigurationEvaluatorProcessor extends AbstractProcessor {
             //Then eval method
             generateEvalMethods(
                 currentElement,
-                new MustacheParams(mClass, mField, mClose, mSubTypeHeader, mSubTypeFooter, mSubTypeCaseHeader, mSubTypeCaseFooter),
+                new MustacheParams(
+                    mClass,
+                    mField,
+                    mClose,
+                    mSubTypeHeader,
+                    mSubTypeFooter,
+                    mSubTypeCaseHeader,
+                    mSubTypeCaseFooter,
+                    mListObjectHeader,
+                    mListObjectFooter
+                ),
                 out,
                 "evaluatedConfiguration",
                 "configuration",
@@ -484,6 +496,65 @@ public class ConfigurationEvaluatorProcessor extends AbstractProcessor {
 
             mustacheParams.mClose().execute(writer, scopes);
         });
+
+        // Process lists of complex objects: iterate over the elements to evaluate their own fields
+        // (e.g. EL in String fields nested inside a List<CustomObject>)
+        convertedFields
+            .get(false)
+            .stream()
+            .filter(fieldProperty -> "List".equals(fieldProperty.getFieldType()))
+            .forEach(fieldProperty -> {
+                TypeElement elementType = getComplexListElementType(fieldProperty.getField());
+                if (elementType == null) {
+                    return;
+                }
+
+                String fieldName = fieldProperty.fieldName;
+                String itemName = fieldName + "Item";
+                String attributeSuffix = currentAttributeSuffix + "." + fieldName;
+
+                Map<String, Object> scopes = new HashMap<>();
+                scopes.put("fieldName", fieldName);
+                scopes.put("itemName", itemName);
+                scopes.put("attributeSuffix", attributeSuffix);
+                scopes.put("elementType", elementType.getQualifiedName().toString());
+                scopes.put("evaluatedList", evaluatedConfigurationName + "." + getGetterMethod(fieldName));
+                mustacheParams.mListObjectHeader().execute(writer, scopes);
+
+                generateEvalMethods(
+                    elementType,
+                    new MustacheParams(mustacheParams),
+                    writer,
+                    itemName,
+                    itemName,
+                    attributeSuffix,
+                    jsonTypeClass,
+                    Collections.emptyList()
+                );
+
+                mustacheParams.mListObjectFooter().execute(writer, scopes);
+            });
+    }
+
+    /**
+     * Returns the element type of a {@code List} field when it is a complex object whose fields must be
+     * evaluated individually (i.e. not a JDK type and not an enum), or {@code null} otherwise.
+     */
+    private TypeElement getComplexListElementType(VariableElement field) {
+        if (!(field.asType() instanceof DeclaredType declaredType) || declaredType.getTypeArguments().size() != 1) {
+            return null;
+        }
+
+        Element element = typeUtils.asElement(declaredType.getTypeArguments().get(0));
+        if (element == null || element.getKind() != ElementKind.CLASS) {
+            return null;
+        }
+
+        TypeElement typeElement = (TypeElement) element;
+        if (typeElement.getQualifiedName().toString().startsWith("java.")) {
+            return null;
+        }
+        return typeElement;
     }
 
     /**
@@ -824,7 +895,9 @@ public class ConfigurationEvaluatorProcessor extends AbstractProcessor {
         Mustache mSubTypeHeader,
         Mustache mSubTypeFooter,
         Mustache mSubTypeCaseHeader,
-        Mustache mSubTypeCaseFooter
+        Mustache mSubTypeCaseFooter,
+        Mustache mListObjectHeader,
+        Mustache mListObjectFooter
     ) {
         public MustacheParams(MustacheParams copy) {
             this(
@@ -834,7 +907,9 @@ public class ConfigurationEvaluatorProcessor extends AbstractProcessor {
                 copy.mSubTypeHeader,
                 copy.mSubTypeFooter,
                 copy.mSubTypeCaseHeader,
-                copy.mSubTypeCaseFooter
+                copy.mSubTypeCaseFooter,
+                copy.mListObjectHeader,
+                copy.mListObjectFooter
             );
         }
     }

--- a/gravitee-plugin-annotation-processors/src/main/resources/templates/evalListObjectFooter.mustache
+++ b/gravitee-plugin-annotation-processors/src/main/resources/templates/evalListObjectFooter.mustache
@@ -1,0 +1,4 @@
+
+            }
+        }
+        //{{fieldName}} list section end

--- a/gravitee-plugin-annotation-processors/src/main/resources/templates/evalListObjectHeader.mustache
+++ b/gravitee-plugin-annotation-processors/src/main/resources/templates/evalListObjectHeader.mustache
@@ -1,8 +1,8 @@
 
         //{{fieldName}} list section begin
         if({{evaluatedList}} != null) {
-            currentAttributePrefix = attributePrefix.concat("{{attributeSuffix}}");
             for ({{elementType}} {{itemName}} : {{evaluatedList}}) {
                 if ({{itemName}} == null) {
                     continue;
                 }
+                currentAttributePrefix = attributePrefix.concat("{{attributeSuffix}}");

--- a/gravitee-plugin-annotation-processors/src/main/resources/templates/evalListObjectHeader.mustache
+++ b/gravitee-plugin-annotation-processors/src/main/resources/templates/evalListObjectHeader.mustache
@@ -1,0 +1,8 @@
+
+        //{{fieldName}} list section begin
+        if({{evaluatedList}} != null) {
+            currentAttributePrefix = attributePrefix.concat("{{attributeSuffix}}");
+            for ({{elementType}} {{itemName}} : {{evaluatedList}}) {
+                if ({{itemName}} == null) {
+                    continue;
+                }

--- a/gravitee-plugin-annotation-processors/src/main/resources/templates/evaluatorHeader.mustache
+++ b/gravitee-plugin-annotation-processors/src/main/resources/templates/evaluatorHeader.mustache
@@ -194,10 +194,17 @@ public class {{evaluatorSimpleClassName}} {
         return value;
     }
 
+    @SuppressWarnings("unchecked")
     private <T> List<T> evalListProperty(String name, List<T> value, String attributePrefix, BaseExecutionContext ctx) {
         List<T> attribute = ctx.getAttributeAsList(buildAttributeName(attributePrefix, name));
         if (attribute != null) {
-            return attribute;
+            // Complex list elements are mutated in place by the per-element EL evaluation, so return a
+            // deep copy to avoid mutating objects owned by the execution-context attribute
+            List<T> copy = new ArrayList<>(attribute.size());
+            for (T element : attribute) {
+                copy.add(element == null ? null : (T) objectMapper.convertValue(element, element.getClass()));
+            }
+            return copy;
         }
 
         return value;

--- a/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/ConfigurationEvaluatorGeneratedTest.java
+++ b/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/ConfigurationEvaluatorGeneratedTest.java
@@ -187,6 +187,37 @@ public class ConfigurationEvaluatorGeneratedTest {
     }
 
     @Test
+    public void should_not_mutate_list_of_objects_provided_as_attribute() {
+        // The per-element EL evaluation must not mutate objects owned by the execution-context attribute
+        TestConfiguration configuration = new TestConfiguration();
+        evaluator = new TestConfigurationEvaluator(configuration);
+
+        var spiedTemplateEngine = spy(new DefaultTemplateEngine());
+        when(spiedTemplateEngine.eval("{#dictionaries['redisDict']['hostVal']}", String.class)).thenReturn(Maybe.just("redis-host"));
+
+        List<HostAndPort> attributeNodes = List.of(
+            new HostAndPort("{#dictionaries['redisDict']['hostVal']}", 12345),
+            new HostAndPort("static-host", 26379)
+        );
+        Map<String, Object> contextMap = new HashMap<>();
+        contextMap.put("gravitee.attributes.endpoint.test.nodes", attributeNodes);
+
+        evaluator
+            .eval(new DefaultExecutionContext(spiedTemplateEngine, contextMap))
+            .test()
+            .assertComplete()
+            .assertValue(testConfiguration -> {
+                assertThat(testConfiguration.getNodes()).extracting(HostAndPort::getHost).containsExactly("redis-host", "static-host");
+                assertThat(testConfiguration.getNodes()).extracting(HostAndPort::getPort).containsExactly(12345, 26379);
+                return true;
+            });
+
+        assertThat(attributeNodes)
+            .extracting(HostAndPort::getHost)
+            .containsExactly("{#dictionaries['redisDict']['hostVal']}", "static-host");
+    }
+
+    @Test
     public void should_cache_evaluated_configuration() {
         when(templateEngine.eval("none", String.class)).thenReturn(Maybe.just("latest"));
         when(templateEngine.eval("password", String.class)).thenReturn(Maybe.just("password"));

--- a/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/ConfigurationEvaluatorGeneratedTest.java
+++ b/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/ConfigurationEvaluatorGeneratedTest.java
@@ -158,6 +158,30 @@ public class ConfigurationEvaluatorGeneratedTest {
     }
 
     @Test
+    public void should_resolve_el_in_list_of_objects() {
+        // Reproduces APIM-14590: EL expressions in String fields nested inside a List<CustomObject> field
+        // must be evaluated through the template engine
+        TestConfiguration configuration = new TestConfiguration();
+        configuration.setNodes(
+            List.of(new HostAndPort("{#dictionaries['redisDict']['hostVal']}", 12345), new HostAndPort("static-host", 26379))
+        );
+        evaluator = new TestConfigurationEvaluator(configuration);
+
+        var spiedTemplateEngine = spy(new DefaultTemplateEngine());
+        when(spiedTemplateEngine.eval("{#dictionaries['redisDict']['hostVal']}", String.class)).thenReturn(Maybe.just("redis-host"));
+
+        evaluator
+            .eval(new DefaultExecutionContext(spiedTemplateEngine))
+            .test()
+            .assertComplete()
+            .assertValue(testConfiguration -> {
+                assertThat(testConfiguration.getNodes()).extracting(HostAndPort::getHost).containsExactly("redis-host", "static-host");
+                assertThat(testConfiguration.getNodes()).extracting(HostAndPort::getPort).containsExactly(12345, 26379);
+                return true;
+            });
+    }
+
+    @Test
     public void should_cache_evaluated_configuration() {
         when(templateEngine.eval("none", String.class)).thenReturn(Maybe.just("latest"));
         when(templateEngine.eval("password", String.class)).thenReturn(Maybe.just("password"));

--- a/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/ConfigurationEvaluatorGeneratedTest.java
+++ b/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/ConfigurationEvaluatorGeneratedTest.java
@@ -179,6 +179,11 @@ public class ConfigurationEvaluatorGeneratedTest {
                 assertThat(testConfiguration.getNodes()).extracting(HostAndPort::getPort).containsExactly(12345, 26379);
                 return true;
             });
+
+        // The per-element loop must mutate only the evaluated deep-clone, never the original configuration
+        assertThat(configuration.getNodes())
+            .extracting(HostAndPort::getHost)
+            .containsExactly("{#dictionaries['redisDict']['hostVal']}", "static-host");
     }
 
     @Test

--- a/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/result/HostAndPort.java
+++ b/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/result/HostAndPort.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.annotation.processor.result;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class HostAndPort {
+
+    private String host;
+
+    private Integer port;
+
+    public HostAndPort() {}
+
+    public HostAndPort(String host, Integer port) {
+        this.host = host;
+        this.port = port;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public Integer getPort() {
+        return port;
+    }
+
+    public void setPort(Integer port) {
+        this.port = port;
+    }
+}

--- a/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/result/TestConfiguration.java
+++ b/gravitee-plugin-annotation-processors/src/test/java/io/gravitee/plugin/annotation/processor/result/TestConfiguration.java
@@ -63,6 +63,9 @@ public class TestConfiguration {
 
     private Double doubleValue;
 
+    //List of complex objects (APIM-14590)
+    private List<HostAndPort> nodes;
+
     public TestConfiguration(
         SecurityProtocol protocol,
         Ssl ssl,
@@ -157,6 +160,14 @@ public class TestConfiguration {
 
     public void setDoubleValue(Double doubleValue) {
         this.doubleValue = doubleValue;
+    }
+
+    public List<HostAndPort> getNodes() {
+        return nodes;
+    }
+
+    public void setNodes(List<HostAndPort> nodes) {
+        this.nodes = nodes;
     }
 
     private static TestConfiguration.Consumer $default$consumer() {

--- a/gravitee-plugin-annotation-processors/src/test/resources/test/TestConfigurationEvaluator.java
+++ b/gravitee-plugin-annotation-processors/src/test/resources/test/TestConfigurationEvaluator.java
@@ -1143,11 +1143,11 @@ public class TestConfigurationEvaluator {
 
         //nodes list section begin
         if(evaluatedConfiguration.getNodes() != null) {
-            currentAttributePrefix = attributePrefix.concat(".nodes");
             for (io.gravitee.plugin.annotation.processor.result.HostAndPort nodesItem : evaluatedConfiguration.getNodes()) {
                 if (nodesItem == null) {
                     continue;
                 }
+                currentAttributePrefix = attributePrefix.concat(".nodes");
                 //Field host
                 if(baseExecutionContext != null) {
                     toEval.add(

--- a/gravitee-plugin-annotation-processors/src/test/resources/test/TestConfigurationEvaluator.java
+++ b/gravitee-plugin-annotation-processors/src/test/resources/test/TestConfigurationEvaluator.java
@@ -194,10 +194,17 @@ public class TestConfigurationEvaluator {
         return value;
     }
 
+    @SuppressWarnings("unchecked")
     private <T> List<T> evalListProperty(String name, List<T> value, String attributePrefix, BaseExecutionContext ctx) {
         List<T> attribute = ctx.getAttributeAsList(buildAttributeName(attributePrefix, name));
         if (attribute != null) {
-            return attribute;
+            // Complex list elements are mutated in place by the per-element EL evaluation, so return a
+            // deep copy to avoid mutating objects owned by the execution-context attribute
+            List<T> copy = new ArrayList<>(attribute.size());
+            for (T element : attribute) {
+                copy.add(element == null ? null : (T) objectMapper.convertValue(element, element.getClass()));
+            }
+            return copy;
         }
 
         return value;

--- a/gravitee-plugin-annotation-processors/src/test/resources/test/TestConfigurationEvaluator.java
+++ b/gravitee-plugin-annotation-processors/src/test/resources/test/TestConfigurationEvaluator.java
@@ -530,7 +530,7 @@ public class TestConfigurationEvaluator {
         //Field nodes
         if(baseExecutionContext != null) {
             evaluatedConfiguration.setNodes(
-                    evalListProperty("nodes", configuration.getNodes(), currentAttributePrefix, baseExecutionContext)
+                    evalListProperty("nodes", evaluatedConfiguration.getNodes(), currentAttributePrefix, baseExecutionContext)
             );
          } else if(deploymentContext != null) {
          }

--- a/gravitee-plugin-annotation-processors/src/test/resources/test/TestConfigurationEvaluator.java
+++ b/gravitee-plugin-annotation-processors/src/test/resources/test/TestConfigurationEvaluator.java
@@ -527,6 +527,13 @@ public class TestConfigurationEvaluator {
             );
          } else if(deploymentContext != null) {
          }
+        //Field nodes
+        if(baseExecutionContext != null) {
+            evaluatedConfiguration.setNodes(
+                    evalListProperty("nodes", configuration.getNodes(), currentAttributePrefix, baseExecutionContext)
+            );
+         } else if(deploymentContext != null) {
+         }
 
         //Consumer section begin
         if(evaluatedConfiguration.getConsumer() != null) {
@@ -1133,6 +1140,35 @@ public class TestConfigurationEvaluator {
 
         }
         //security section end
+
+        //nodes list section begin
+        if(evaluatedConfiguration.getNodes() != null) {
+            currentAttributePrefix = attributePrefix.concat(".nodes");
+            for (io.gravitee.plugin.annotation.processor.result.HostAndPort nodesItem : evaluatedConfiguration.getNodes()) {
+                if (nodesItem == null) {
+                    continue;
+                }
+                //Field host
+                if(baseExecutionContext != null) {
+                    toEval.add(
+                            evalStringProperty("host", nodesItem.getHost(), currentAttributePrefix, baseExecutionContext, "")
+                                    .doOnSuccess(value -> nodesItem.setHost(value))
+                    );
+                } else if(deploymentContext != null) {
+                    toEval.add(
+                            evalStringProperty("host", nodesItem.getHost(), currentAttributePrefix, deploymentContext, "")
+                                    .doOnSuccess(value -> nodesItem.setHost(value)));
+                }
+                //Field port
+                if(baseExecutionContext != null) {
+                    nodesItem.setPort(
+                            evalIntegerProperty("port", nodesItem.getPort(), currentAttributePrefix, baseExecutionContext)
+                    );
+                 } else if(deploymentContext != null) {
+                 }
+            }
+        }
+        //nodes list section end
 
         // Evaluate properties that needs EL, validate evaluatedConf and returns it
         Completable toEvalCompletable = Flowable.fromIterable(toEval).concatMapMaybe(m -> m).ignoreElements();


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14590

EL expressions in `String` fields nested inside a `List<CustomObject>` field of a `@ConfigurationEvaluator` class were silently passed as literal strings (e.g. `nodes[].host` in the cache-redis resource's Sentinel configuration).

## Root cause

`List<CustomObject>` fields are classified as plain `List` fields and dispatched to `evalListProperty`, which only applies a context-attribute override and returns the list untouched. Unlike nested `Object` fields, the generator never recursed into the list's element type, so the template engine was never invoked for the elements' `String` fields — no error, the expression just never ran.

## Fix

After the existing field/object passes, the generator now emits a per-element loop for every `List` field whose element type is a complex object (non-JDK class, not an enum), and recurses into the element type. Nested `String` fields go through `evalStringProperty` (template-engine evaluation + attribute override) exactly like top-level ones; other field types get their usual attribute-override handling. The whole-list attribute override (`evalListProperty`) is preserved and runs before element evaluation.

## Tests

- New fixture `HostAndPort` + `List<HostAndPort> nodes` field on `TestConfiguration`, mirroring the cache-redis Sentinel case, with the expected generated code added to the golden file (`shouldGenerateTheExpectedResultFile`).
- New runtime test `should_resolve_el_in_list_of_objects` asserting an EL expression in `nodes[0].host` is resolved while literal hosts and ports pass through untouched. Both tests were written first and failed before the fix.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.1.5-fix-APIM-14590-el-list-object-config-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/plugin/gravitee-plugin/5.1.5-fix-APIM-14590-el-list-object-config-SNAPSHOT/gravitee-plugin-5.1.5-fix-APIM-14590-el-list-object-config-SNAPSHOT.zip)
  <!-- Version placeholder end -->
